### PR TITLE
My Garden Backend + Manage Garden Hotfix

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
@@ -52,8 +52,9 @@ public class ManageGardenActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Toast.makeText(ManageGardenActivity.this, "Back Arrow pressed", Toast.LENGTH_SHORT).show();
-                Intent mapsActivity = new Intent(ManageGardenActivity.this, MyGardenYesGardenActivity.class);
-                startActivity(mapsActivity);
+                Intent intent = new Intent(ManageGardenActivity.this, MyGardenYesGardenActivity.class);
+                googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+                startActivity(intent);
             }
         });
 

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenNoGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenNoGardenActivity.java
@@ -26,14 +26,6 @@ public class MyGardenNoGardenActivity extends NavBarActivity {
             startActivity(mapsIntent);
         });
 
-        Button tempButton = findViewById(R.id.temp_button_yes_garden);
-        tempButton.setOnClickListener(view -> {
-            Log.d(TAG, "Clicking Temp Yes Garden Button");
-            Intent intent = new Intent(MyGardenNoGardenActivity.this, MyGardenYesGardenActivity.class);
-            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
-            startActivity(intent);
-        });
-
     }
 
     /**

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -1,15 +1,34 @@
 package com.plotpals.client;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.android.volley.toolbox.Volley;
 import com.plotpals.client.utils.GoogleProfileInformation;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MyGardenYesGardenActivity extends NavBarActivity {
     final static String TAG = "MyGardenYesGardenActivity";
+    private int upperManagedGardens = 0;
+    private int upperGardens = 0;
     GoogleProfileInformation googleProfileInformation;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -26,20 +45,7 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
             startActivity(mapsIntent);
         });
 
-        Button forumButton = findViewById(R.id.my_garden_1_forum);
-        forumButton.setOnClickListener(view -> {
-            Log.d(TAG, "Clicking Forum Button");
-            Intent intent = new Intent(MyGardenYesGardenActivity.this, ForumBoardMainActivity.class);
-            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
-            startActivity(intent);
-        });
-
-        findViewById(R.id.my_garden_1_manage).setOnClickListener(view -> {
-            Log.d(TAG, "Clicking Manage Button");
-            Intent intent = new Intent(MyGardenYesGardenActivity.this, ManageGardenActivity.class);
-            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
-            startActivity(intent);
-        });
+        loadGardens();
     }
 
     /**
@@ -52,4 +58,111 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
             googleProfileInformation = new GoogleProfileInformation(extras);
         }
     }
+
+    private void loadGardens() {
+        RequestQueue volleyQueue = Volley.newRequestQueue(this);
+        String url = "http://10.0.2.2:8081/gardens";
+        Request<?> jsonObjectRequest = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                null,
+                (JSONObject response) -> {
+                    try {
+                        Log.d(TAG, "Obtaining my gardens");
+                        JSONArray fetchedGardens = (JSONArray)response.get("data");
+                        Log.d(TAG, "Gardens: " + fetchedGardens.length());
+
+                        // loop and add every garden
+                        for (int i = 0; i < fetchedGardens.length(); i++) {
+                            JSONObject garden = fetchedGardens.getJSONObject(i);
+                            Log.d(TAG, "Account User ID: " + googleProfileInformation.getAccountUserId());
+                            Log.d(TAG, "Owner User ID: " + garden.getString("gardenOwnerId"));
+                            if (googleProfileInformation.getAccountUserId().equals(garden.getString("gardenOwnerId"))) {
+                                addManagedGarden(garden.getString("gardenName"), 0);
+                                upperManagedGardens++;
+                            } else {
+                                addGarden(garden.getString("gardenName"), 0);
+                                upperGardens++;
+                            }
+                        }
+
+                        Bundle extras = getIntent().getExtras();
+                        assert extras != null;
+                    } catch (JSONException e) {
+                        Log.d(TAG, e.toString());
+                    }
+                },
+                (VolleyError e) -> {
+                    Log.d(TAG, e.toString());
+                }
+        ) {
+            @Override
+            public Map<String, String> getHeaders() {
+                HashMap<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + googleProfileInformation.getAccountIdToken());
+                return headers;
+            }
+        };
+        volleyQueue.add(jsonObjectRequest);
+    }
+
+    private void addManagedGarden(String name, int id) {
+        // Set view
+        RelativeLayout layout = findViewById(R.id.my_garden_scrollview_layout);
+        LayoutInflater layoutInflater = (LayoutInflater)
+                this.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View managedGardenView = layoutInflater.inflate(R.layout.activity_my_garden_managed_garden, layout, false);
+
+        // Translate view downwards based on how many
+        defineMargins(managedGardenView, upperManagedGardens, upperGardens);
+
+        // Link buttons
+        Button forumButton = managedGardenView.findViewById(R.id.my_garden_managed_forum_button);
+        setForumButton(forumButton, 0);
+        Button manageButton = managedGardenView.findViewById(R.id.my_garden_managed_manage_button);
+        setManageButton(manageButton, 0);
+
+        layout.addView(managedGardenView);
+    }
+
+    private void addGarden(String name, int id) {
+        // Set view
+        RelativeLayout layout = findViewById(R.id.my_garden_scrollview_layout);
+        LayoutInflater layoutInflater = (LayoutInflater)
+                this.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View gardenView = layoutInflater.inflate(R.layout.activity_my_garden_garden, layout, false);
+
+        // Translate view downwards based on how many
+        defineMargins(gardenView, upperManagedGardens, upperGardens);
+
+        // Link buttons
+        Button forumButton = gardenView.findViewById(R.id.my_garden_forum_button);
+        setForumButton(forumButton, 0);
+
+        layout.addView(gardenView);
+    }
+
+    private void defineMargins (View v, int upperManagedGardens, int upperGardens) {
+        ViewGroup.MarginLayoutParams margins = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+        margins.setMargins(margins.leftMargin, margins.topMargin + upperManagedGardens * 540 + upperGardens * 430, margins.rightMargin, margins.bottomMargin);
+    }
+
+    private void setForumButton(Button forumButton, int id) {
+        forumButton.setOnClickListener(view -> {
+            Log.d(TAG, "Clicking Forum Button");
+            Intent intent = new Intent(MyGardenYesGardenActivity.this, ForumBoardMainActivity.class);
+            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+            startActivity(intent);
+        });
+    }
+
+    private void setManageButton(Button manageButton, int id) {
+        manageButton.setOnClickListener(view -> {
+            Log.d(TAG, "Clicking Manage Button");
+            Intent intent = new Intent(MyGardenYesGardenActivity.this, ManageGardenActivity.class);
+            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+            startActivity(intent);
+        });
+    }
+
 }

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -123,6 +123,8 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         setForumButton(forumButton, 0);
         Button manageButton = managedGardenView.findViewById(R.id.my_garden_managed_manage_button);
         setManageButton(manageButton, 0);
+        Button membersButton = managedGardenView.findViewById(R.id.my_garden_managed_members_button);
+        setMembersButton(membersButton, 0);
 
         // Set Garden Name
         TextView textView = managedGardenView.findViewById(R.id.my_garden_managed_name);
@@ -144,6 +146,8 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         // Link buttons
         Button forumButton = gardenView.findViewById(R.id.my_garden_forum_button);
         setForumButton(forumButton, 0);
+        Button membersButton = gardenView.findViewById(R.id.my_garden_members_button);
+        setMembersButton(membersButton, 0);
 
         // Set Garden Name
         TextView textView = gardenView.findViewById(R.id.my_garden_name);
@@ -170,6 +174,15 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         manageButton.setOnClickListener(view -> {
             Log.d(TAG, "Clicking Manage Button");
             Intent intent = new Intent(MyGardenYesGardenActivity.this, ManageGardenActivity.class);
+            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+            startActivity(intent);
+        });
+    }
+
+    private void setMembersButton(Button membersButton, int id) {
+        membersButton.setOnClickListener(view -> {
+            Log.d(TAG, "Clicking Members Button");
+            Intent intent = new Intent(MyGardenYesGardenActivity.this, CurrentMembersActivity.class);
             googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
             startActivity(intent);
         });

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
@@ -21,6 +22,7 @@ import com.plotpals.client.utils.GoogleProfileInformation;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.w3c.dom.Text;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -122,6 +124,10 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         Button manageButton = managedGardenView.findViewById(R.id.my_garden_managed_manage_button);
         setManageButton(manageButton, 0);
 
+        // Set Garden Name
+        TextView textView = managedGardenView.findViewById(R.id.my_garden_managed_name);
+        textView.setText(name);
+
         layout.addView(managedGardenView);
     }
 
@@ -139,12 +145,16 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         Button forumButton = gardenView.findViewById(R.id.my_garden_forum_button);
         setForumButton(forumButton, 0);
 
+        // Set Garden Name
+        TextView textView = gardenView.findViewById(R.id.my_garden_name);
+        textView.setText(name);
+
         layout.addView(gardenView);
     }
 
     private void defineMargins (View v, int upperManagedGardens, int upperGardens) {
         ViewGroup.MarginLayoutParams margins = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-        margins.setMargins(margins.leftMargin, margins.topMargin + upperManagedGardens * 540 + upperGardens * 430, margins.rightMargin, margins.bottomMargin);
+        margins.setMargins(margins.leftMargin, margins.topMargin + upperManagedGardens * 580 + upperGardens * 470, margins.rightMargin, margins.bottomMargin);
     }
 
     private void setForumButton(Button forumButton, int id) {

--- a/frontend/app/src/main/java/com/plotpals/client/NavBarActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/NavBarActivity.java
@@ -7,13 +7,26 @@ import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.android.volley.toolbox.Volley;
 import com.plotpals.client.utils.GoogleProfileInformation;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class NavBarActivity extends AppCompatActivity {
 
     final static String TAG = "NavBarActivity";
 
     GoogleProfileInformation googleProfileInformation;
+    private boolean haveGardens = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,12 +43,11 @@ public class NavBarActivity extends AppCompatActivity {
             startActivity(intent);
         });
 
+        // Can be optimized, but whatever for now.
         Button gardenButton = findViewById(R.id.button_navbar_garden);
         gardenButton.setOnClickListener(view -> {
             Log.d(TAG, "Clicking My Garden Button");
-            Intent intent = new Intent(NavBarActivity.this, MyGardenNoGardenActivity.class);
-            googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
-            startActivity(intent);
+            startGardenActivity();
         });
 
         Button accountButton = findViewById(R.id.button_navbar_account);
@@ -57,4 +69,47 @@ public class NavBarActivity extends AppCompatActivity {
             googleProfileInformation = new GoogleProfileInformation(extras);
         }
     }
+
+    private void startGardenActivity() {
+        RequestQueue volleyQueue = Volley.newRequestQueue(this);
+        String url = "http://10.0.2.2:8081/gardens";
+        Request<?> jsonObjectRequest = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                null,
+                (JSONObject response) -> {
+                    try {
+                        Log.d(TAG, "Obtaining my gardens");
+                        JSONArray fetchedGardens = (JSONArray)response.get("data");
+                        Log.d(TAG, "Gardens: " + fetchedGardens.length());
+                        Intent intent;
+                        if (fetchedGardens.length() > 0) {
+                            Log.d(TAG, "Have Gardens, opening Garden Page");
+                            intent = new Intent(NavBarActivity.this, MyGardenYesGardenActivity.class);
+                        } else {
+                            Log.d(TAG, "Don't have Gardens, opening Empty Garden Page");
+                            intent = new Intent(NavBarActivity.this, MyGardenNoGardenActivity.class);
+                        }
+                        Bundle extras = getIntent().getExtras();
+                        assert extras != null;
+                        googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+                        startActivity(intent);
+                    } catch (JSONException e) {
+                        Log.d(TAG, e.toString());
+                    }
+                },
+                (VolleyError e) -> {
+                    Log.d(TAG, e.toString());
+                }
+        ) {
+            @Override
+            public Map<String, String> getHeaders() {
+                HashMap<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + googleProfileInformation.getAccountIdToken());
+                return headers;
+            }
+        };
+        volleyQueue.add(jsonObjectRequest);
+    }
+
 }

--- a/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
@@ -34,7 +34,7 @@
         app:layout_constraintVertical_bias="0.142" />
 
     <Button
-        android:id="@+id/my_garden_2_member"
+        android:id="@+id/my_garden_members_button"
         android:layout_width="125dp"
         android:layout_height="36dp"
         android:autoSizeTextType="uniform"
@@ -59,7 +59,7 @@
         app:layout_constraintEnd_toEndOf="@+id/view"
         app:layout_constraintHorizontal_bias="0.917"
         app:layout_constraintStart_toStartOf="@+id/view"
-        app:layout_constraintTop_toBottomOf="@+id/my_garden_2_member"
+        app:layout_constraintTop_toBottomOf="@+id/my_garden_members_button"
         app:layout_constraintVertical_bias="0.333" />
 
 

--- a/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
@@ -17,8 +17,9 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/textView"
-        android:layout_width="141dp"
+        android:id="@+id/my_garden_name"
+        android:layout_width="280dp"
+        android:autoSizeTextType="uniform"
         android:layout_height="32dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
@@ -27,10 +28,10 @@
         android:textAppearance="@style/label_text_big"
         app:layout_constraintBottom_toBottomOf="@+id/view"
         app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.103"
+        app:layout_constraintHorizontal_bias="0.423"
         app:layout_constraintStart_toStartOf="@+id/view"
         app:layout_constraintTop_toTopOf="@+id/view"
-        app:layout_constraintVertical_bias="0.122" />
+        app:layout_constraintVertical_bias="0.142" />
 
     <Button
         android:id="@+id/my_garden_2_member"

--- a/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <View
+        android:id="@+id/view"
+        android:layout_width="306dp"
+        android:layout_height="144dp"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:background="@drawable/my_garden_normal_rectangle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="141dp"
+        android:layout_height="32dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:gravity="top"
+        android:text="@string/garden_name"
+        android:textAppearance="@style/label_text_big"
+        app:layout_constraintBottom_toBottomOf="@+id/view"
+        app:layout_constraintEnd_toEndOf="@+id/view"
+        app:layout_constraintHorizontal_bias="0.103"
+        app:layout_constraintStart_toStartOf="@+id/view"
+        app:layout_constraintTop_toTopOf="@+id/view"
+        app:layout_constraintVertical_bias="0.122" />
+
+    <Button
+        android:id="@+id/my_garden_2_member"
+        android:layout_width="125dp"
+        android:layout_height="36dp"
+        android:autoSizeTextType="uniform"
+        android:text="Member Portal"
+        android:textAppearance="@style/basic_text"
+        app:layout_constraintBottom_toBottomOf="@+id/view"
+        app:layout_constraintEnd_toEndOf="@+id/view"
+        app:layout_constraintHorizontal_bias="0.917"
+        app:layout_constraintStart_toStartOf="@+id/view"
+        app:layout_constraintTop_toTopOf="@+id/view"
+        app:layout_constraintVertical_bias="0.49" />
+
+    <Button
+        android:id="@+id/my_garden_forum_button"
+        android:layout_width="125dp"
+        android:layout_height="36dp"
+        android:layout_marginBottom="16dp"
+        android:autoSizeTextType="uniform"
+        android:text="Forum Board"
+        android:textAppearance="@style/basic_text"
+        app:layout_constraintBottom_toBottomOf="@+id/view"
+        app:layout_constraintEnd_toEndOf="@+id/view"
+        app:layout_constraintHorizontal_bias="0.917"
+        app:layout_constraintStart_toStartOf="@+id/view"
+        app:layout_constraintTop_toBottomOf="@+id/my_garden_2_member"
+        app:layout_constraintVertical_bias="0.333" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
@@ -40,11 +40,11 @@
         app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
         app:layout_constraintHorizontal_bias="0.914"
         app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
-        app:layout_constraintTop_toBottomOf="@+id/my_garden_1_member"
+        app:layout_constraintTop_toBottomOf="@+id/my_garden_managed_members_button"
         app:layout_constraintVertical_bias="0.478" />
 
     <Button
-        android:id="@+id/my_garden_1_member"
+        android:id="@+id/my_garden_managed_members_button"
         android:layout_width="125dp"
         android:layout_height="36dp"
         android:layout_marginTop="48dp"

--- a/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
@@ -57,20 +57,21 @@
         app:layout_constraintTop_toTopOf="@+id/my_garden_big_view" />
 
     <TextView
-        android:id="@+id/textView7"
-        android:layout_width="141dp"
+        android:id="@+id/my_garden_managed_name"
+        android:layout_width="280dp"
         android:layout_height="32dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:autoSizeTextType="uniform"
         android:gravity="top"
         android:text="@string/garden_name"
         android:textAppearance="@style/label_text_big"
         app:layout_constraintBottom_toBottomOf="@+id/my_garden_big_view"
         app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
-        app:layout_constraintHorizontal_bias="0.103"
+        app:layout_constraintHorizontal_bias="0.384"
         app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
         app:layout_constraintTop_toTopOf="@+id/my_garden_big_view"
-        app:layout_constraintVertical_bias="0.122" />
+        app:layout_constraintVertical_bias="0.103" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <View
+        android:id="@+id/my_garden_big_view"
+        android:layout_width="306dp"
+        android:layout_height="187dp"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:background="@drawable/my_garden_big_rectangle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/my_garden_managed_manage_button"
+        android:layout_width="125dp"
+        android:layout_height="36dp"
+        android:layout_marginBottom="20dp"
+        android:autoSizeTextType="uniform"
+        android:text="Manage Garden"
+        android:textAppearance="@style/basic_text"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_big_view"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
+        app:layout_constraintHorizontal_bias="0.914"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_big_view" />
+
+    <Button
+        android:id="@+id/my_garden_managed_forum_button"
+        android:layout_width="125dp"
+        android:layout_height="36dp"
+        android:autoSizeTextType="uniform"
+        android:text="Forum Board"
+        android:textAppearance="@style/basic_text"
+        app:layout_constraintBottom_toTopOf="@+id/my_garden_managed_manage_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
+        app:layout_constraintHorizontal_bias="0.914"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
+        app:layout_constraintTop_toBottomOf="@+id/my_garden_1_member"
+        app:layout_constraintVertical_bias="0.478" />
+
+    <Button
+        android:id="@+id/my_garden_1_member"
+        android:layout_width="125dp"
+        android:layout_height="36dp"
+        android:layout_marginTop="48dp"
+        android:autoSizeTextType="uniform"
+        android:text="Member Portal"
+        android:textAppearance="@style/basic_text"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
+        app:layout_constraintHorizontal_bias="0.914"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_big_view" />
+
+    <TextView
+        android:id="@+id/textView7"
+        android:layout_width="141dp"
+        android:layout_height="32dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:gravity="top"
+        android:text="@string/garden_name"
+        android:textAppearance="@style/label_text_big"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_big_view"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
+        app:layout_constraintHorizontal_bias="0.103"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_big_view"
+        app:layout_constraintVertical_bias="0.122" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_no_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_no_garden.xml
@@ -10,18 +10,6 @@
         android:id="@+id/include2"
         layout="@layout/activity_nav_bar" />
 
-    <Button
-        android:id="@+id/temp_button_yes_garden"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="yes garden page (temp)"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.501"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.666" />
-
     <TextView
         android:id="@+id/my_garden_header_text"
         android:layout_width="177dp"

--- a/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
@@ -16,13 +16,10 @@
         android:id="@+id/my_garden_plus_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="80dp"
         android:layout_marginEnd="36dp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toEndOf="@+id/my_garden_header_text"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.114"
         app:srcCompat="@drawable/add" />
 
     <TextView
@@ -50,8 +47,7 @@
         <RelativeLayout
             android:id="@+id/my_garden_scrollview_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-        />
+            android:layout_height="wrap_content" />
     </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
@@ -12,79 +12,6 @@
         tools:layout_editor_absoluteX="0dp"
         tools:layout_editor_absoluteY="0dp" />
 
-    <View
-        android:id="@+id/view2"
-        android:layout_width="306dp"
-        android:layout_height="187dp"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="56dp"
-        android:background="@drawable/my_garden_big_rectangle"
-        app:layout_constraintBottom_toBottomOf="@+id/include3"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.523"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/my_garden_header_text"
-        app:layout_constraintVertical_bias="0.082" />
-
-    <View
-        android:id="@+id/view"
-        android:layout_width="306dp"
-        android:layout_height="144dp"
-        android:layout_alignParentTop="true"
-        android:layout_centerHorizontal="true"
-        android:background="@drawable/my_garden_normal_rectangle"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/include3"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/view2"
-        app:layout_constraintVertical_bias="0.233" />
-
-    <Button
-        android:id="@+id/my_garden_2_forum"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:layout_marginBottom="16dp"
-        android:autoSizeTextType="uniform"
-        android:text="Forum Board"
-        android:textAppearance="@style/basic_text"
-        app:layout_constraintBottom_toBottomOf="@+id/view"
-        app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.917"
-        app:layout_constraintStart_toStartOf="@+id/view"
-        app:layout_constraintTop_toBottomOf="@+id/my_garden_2_member"
-        app:layout_constraintVertical_bias="0.333" />
-
-    <Button
-        android:id="@+id/my_garden_2_member"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:autoSizeTextType="uniform"
-        android:text="Member Portal"
-        android:textAppearance="@style/basic_text"
-        app:layout_constraintBottom_toBottomOf="@+id/view"
-        app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.917"
-        app:layout_constraintStart_toStartOf="@+id/view"
-        app:layout_constraintTop_toTopOf="@+id/view"
-        app:layout_constraintVertical_bias="0.49" />
-
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="141dp"
-        android:layout_height="32dp"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:gravity="top"
-        android:text="@string/garden_name"
-        android:textAppearance="@style/label_text_big"
-        app:layout_constraintBottom_toBottomOf="@+id/view"
-        app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.103"
-        app:layout_constraintStart_toStartOf="@+id/view"
-        app:layout_constraintTop_toTopOf="@+id/view"
-        app:layout_constraintVertical_bias="0.122" />
-
     <ImageView
         android:id="@+id/my_garden_plus_button"
         android:layout_width="wrap_content"
@@ -112,59 +39,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:layout_width="141dp"
-        android:layout_height="32dp"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:gravity="top"
-        android:text="@string/garden_name"
-        android:textAppearance="@style/label_text_big"
-        app:layout_constraintBottom_toBottomOf="@+id/view2"
-        app:layout_constraintEnd_toEndOf="@+id/view2"
-        app:layout_constraintHorizontal_bias="0.103"
-        app:layout_constraintStart_toStartOf="@+id/view2"
-        app:layout_constraintTop_toTopOf="@+id/view2"
-        app:layout_constraintVertical_bias="0.122" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="530dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/include3"
+        app:layout_constraintVertical_bias="0.661"
+        tools:layout_editor_absoluteX="0dp">
 
-    <Button
-        android:id="@+id/my_garden_1_forum"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:autoSizeTextType="uniform"
-        android:text="Forum Board"
-        android:textAppearance="@style/basic_text"
-        app:layout_constraintBottom_toTopOf="@+id/my_garden_1_manage"
-        app:layout_constraintEnd_toEndOf="@+id/view2"
-        app:layout_constraintHorizontal_bias="0.914"
-        app:layout_constraintStart_toStartOf="@+id/view2"
-        app:layout_constraintTop_toBottomOf="@+id/my_garden_1_member"
-        app:layout_constraintVertical_bias="0.478" />
-
-    <Button
-        android:id="@+id/my_garden_1_member"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:layout_marginTop="48dp"
-        android:autoSizeTextType="uniform"
-        android:text="Member Portal"
-        android:textAppearance="@style/basic_text"
-        app:layout_constraintEnd_toEndOf="@+id/view2"
-        app:layout_constraintHorizontal_bias="0.914"
-        app:layout_constraintStart_toStartOf="@+id/view2"
-        app:layout_constraintTop_toTopOf="@+id/view2" />
-
-    <Button
-        android:id="@+id/my_garden_1_manage"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:layout_marginBottom="20dp"
-        android:autoSizeTextType="uniform"
-        android:text="Manage Garden"
-        android:textAppearance="@style/basic_text"
-        app:layout_constraintBottom_toBottomOf="@+id/view2"
-        app:layout_constraintEnd_toEndOf="@+id/view2"
-        app:layout_constraintHorizontal_bias="0.914"
-        app:layout_constraintStart_toStartOf="@+id/view2" />
+        <RelativeLayout
+            android:id="@+id/my_garden_scrollview_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+        />
+    </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="create_profile_display_name_text_input_hint">Enter Display Name</string>
 
     <string name="account_name_placeholder">Name</string>
-    <string name="navbar_garden_text">My Garden</string>
+    <string name="navbar_garden_text">My Gardens</string>
     <string name="navbar_home_text">Home</string>
     <string name="navbar_account_text">Account</string>
     <string name="header_account_main">My Account</string>


### PR DESCRIPTION
Lots of stuff going on in the code, let me know if you need an explanation.

**Notable Changes**
- NavBar "My Gardens" now calls the back end to check if you joined any gardens, to lead you to the correct activity.
- Each Garden on the page is now a real garden from the back end, and dynamically adds/removes gardens based on whats there
- The buttons on the gardens still lead to the static pages, will be implemented in the future
- Hotfix on the Manage Garden's back button
- TODO: I linked the members portal, but now the back button for that is confused about where it came from. needs fixing in the future.

**Try it out**
- Navbar -> My Gardens
- Try scrolling
- Try pressing the buttons

![image](https://github.com/ngjstn/plot-pals/assets/57464218/b1fac5be-a0bf-4579-8bbc-24cc1412b240)
