### PR TITLE
MyGarden button routing for manage and members page

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
@@ -19,6 +19,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.plotpals.client.data.Garden;
 import com.plotpals.client.data.Role;
 import com.plotpals.client.data.RoleEnum;
 import com.plotpals.client.utils.GoogleProfileInformation;
@@ -95,6 +96,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
                 else {
                     Intent manageActivity = new Intent(CurrentMembersActivity.this, ManageGardenActivity.class);
                     googleProfileInformation.loadGoogleProfileInformationToIntent(manageActivity);
+                    manageActivity.putExtra("gardenId", gardenId);
                     startActivity(manageActivity);
                 }
             }
@@ -172,4 +174,5 @@ public class CurrentMembersActivity extends AppCompatActivity {
             cameFromMyGardenYesPage = extras.getBoolean("CameFromMyGardenYes");
         }
     }
+
 }

--- a/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
@@ -41,6 +41,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
     ArrayList<Role> caretakerList;
     ArrayAdapter<Role> caretakerAdapter;
     int gardenId;
+    boolean cameFromMyGardenYesPage = false;
     
     static GoogleProfileInformation googleProfileInformation;
 
@@ -86,8 +87,16 @@ public class CurrentMembersActivity extends AppCompatActivity {
         findViewById(R.id.arrow_back_).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Intent manageActivity = new Intent(CurrentMembersActivity.this, ManageGardenActivity.class);
-                startActivity(manageActivity);
+                if (cameFromMyGardenYesPage) {
+                    Intent myGardenYes = new Intent(CurrentMembersActivity.this, MyGardenYesGardenActivity.class);
+                    googleProfileInformation.loadGoogleProfileInformationToIntent(myGardenYes);
+                    startActivity(myGardenYes);
+                }
+                else {
+                    Intent manageActivity = new Intent(CurrentMembersActivity.this, ManageGardenActivity.class);
+                    googleProfileInformation.loadGoogleProfileInformationToIntent(manageActivity);
+                    startActivity(manageActivity);
+                }
             }
         });
     }
@@ -160,6 +169,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
         if (extras != null) {
             googleProfileInformation = new GoogleProfileInformation(extras);
             gardenId = extras.getInt("gardenId");
+            cameFromMyGardenYesPage = extras.getBoolean("CameFromMyGardenYes");
         }
     }
 }

--- a/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
@@ -181,13 +181,11 @@ public class ManageGardenActivity extends AppCompatActivity {
     }
 
     private void updateGardenOverlayContent(Garden garden) {
-        TextView gardenName = findViewById(R.id.garden_name);
         TextView address = findViewById(R.id.something_r);
         TextView contactName = findViewById(R.id.contact_nam);
         TextView contactEmail = findViewById(R.id.name_email_);
         TextView contactPhone = findViewById(R.id.some_id);
 
-        gardenName.setText(garden.getGardenName());
         address.setText(garden.getAddress());
         contactName.setText(garden.getGardenOwnerName());
         contactEmail.setText(garden.getContactEmail());

--- a/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.android.volley.Request;
@@ -15,6 +16,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.plotpals.client.data.Garden;
 import com.plotpals.client.data.Role;
 import com.plotpals.client.data.Task;
 import com.plotpals.client.utils.GoogleProfileInformation;
@@ -35,6 +37,7 @@ public class ManageGardenActivity extends AppCompatActivity {
     ListView memberListView;
     ArrayAdapter<String> memberListAdapter;
     Integer currentGardenId;
+    Garden currentGarden;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -85,6 +88,7 @@ public class ManageGardenActivity extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
         requestMembers(currentGardenId);
+        requestGardenInfo(currentGardenId);
     }
 
     private void requestMembers(Integer gardenId) {
@@ -130,7 +134,43 @@ public class ManageGardenActivity extends AppCompatActivity {
 
         volleyQueue.add(jsonObjectRequest);
     }
+    
+    private void requestGardenInfo(Integer gardenId) {
+        RequestQueue volleyQueue = Volley.newRequestQueue(this);
+        String url = String.format("http://10.0.2.2:8081/gardens/all?gardenId=%s", gardenId);
 
+        Request<?> jsonObjectRequest = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                null,
+
+                (JSONObject response) -> {
+                    try {
+                        Log.d(TAG, "Obtaining garden info");
+                        JSONArray fetchedGarden = (JSONArray)response.get("data");
+                        JSONObject gardenJson = fetchedGarden.getJSONObject(0);
+                        currentGarden = new Garden(gardenJson);
+                        updateGardenOverlayContent(currentGarden);
+
+                    } catch (JSONException e) {
+                        Log.d(TAG, e.toString());
+                    }
+                },
+                (VolleyError e) -> {
+                    Log.d(TAG, e.toString());
+                }
+        ) {
+            @Override
+            public Map<String, String> getHeaders() {
+                HashMap<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + googleProfileInformation.getAccountIdToken());
+                return headers;
+            }
+        };
+
+        volleyQueue.add(jsonObjectRequest);
+    }
+    
     private void loadExtras() {
         Bundle extras = getIntent().getExtras();
 
@@ -138,5 +178,19 @@ public class ManageGardenActivity extends AppCompatActivity {
             googleProfileInformation = new GoogleProfileInformation(extras);
             currentGardenId = extras.getInt("gardenId");
         }
+    }
+
+    private void updateGardenOverlayContent(Garden garden) {
+        TextView gardenName = findViewById(R.id.garden_name);
+        TextView address = findViewById(R.id.something_r);
+        TextView contactName = findViewById(R.id.contact_nam);
+        TextView contactEmail = findViewById(R.id.name_email_);
+        TextView contactPhone = findViewById(R.id.some_id);
+
+        gardenName.setText(garden.getGardenName());
+        address.setText(garden.getAddress());
+        contactName.setText(garden.getGardenOwnerName());
+        contactEmail.setText(garden.getContactEmail());
+        contactPhone.setText(garden.getContactPhoneNumber());
     }
 }

--- a/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
@@ -34,6 +34,7 @@ public class ManageGardenActivity extends AppCompatActivity {
     ArrayList<Role> memberList;
     ListView memberListView;
     ArrayAdapter<String> memberListAdapter;
+    Integer currentGardenId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -73,7 +74,7 @@ public class ManageGardenActivity extends AppCompatActivity {
             public void onClick(View view) {
                 Intent currentMemActivity = new Intent(ManageGardenActivity.this, CurrentMembersActivity.class);
                 googleProfileInformation.loadGoogleProfileInformationToIntent(currentMemActivity);
-                currentMemActivity.putExtra("gardenId", 4);
+                currentMemActivity.putExtra("gardenId", currentGardenId);
                 startActivity(currentMemActivity);
             }
         });
@@ -83,8 +84,7 @@ public class ManageGardenActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        // TODO: Hard coding the gardenId for now. Eventually, the parent activity should pass in the gardenId.
-        requestMembers(4);
+        requestMembers(currentGardenId);
     }
 
     private void requestMembers(Integer gardenId) {
@@ -136,6 +136,7 @@ public class ManageGardenActivity extends AppCompatActivity {
 
         if (extras != null) {
             googleProfileInformation = new GoogleProfileInformation(extras);
+            currentGardenId = extras.getInt("gardenId");
         }
     }
 }

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -320,13 +320,13 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     private void updateGardenOverlayContent(Garden garden) {
         TextView gardenName = findViewById(R.id.garden_name);
         TextView address = findViewById(R.id.something_r);
-//        TextView contactName = findViewById(R.id.contact_nam);
+        TextView contactName = findViewById(R.id.contact_nam);
         TextView contactEmail = findViewById(R.id.name_email_);
         TextView contactPhone = findViewById(R.id.some_id);
 
         gardenName.setText(garden.getGardenName());
         address.setText(garden.getAddress());
-//        contactName.setText(garden.getContactName());
+       contactName.setText(garden.getGardenOwnerName());
         contactEmail.setText(garden.getContactEmail());
         contactPhone.setText(garden.getContactPhoneNumber());
     }

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -17,6 +17,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
+import com.plotpals.client.data.Garden;
 import com.plotpals.client.utils.GoogleProfileInformation;
 
 import org.json.JSONArray;
@@ -79,11 +80,12 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
                             JSONObject garden = fetchedGardens.getJSONObject(i);
                             Log.d(TAG, "Account User ID: " + googleProfileInformation.getAccountUserId());
                             Log.d(TAG, "Owner User ID: " + garden.getString("gardenOwnerId"));
+                            Garden gardenObj = new Garden(garden);
                             if (googleProfileInformation.getAccountUserId().equals(garden.getString("gardenOwnerId"))) {
-                                addManagedGarden(garden.getString("gardenName"), 0);
+                                addManagedGarden(garden.getString("gardenName"), gardenObj);
                                 upperManagedGardens++;
                             } else {
-                                addGarden(garden.getString("gardenName"), 0);
+                                addGarden(garden.getString("gardenName"), gardenObj);
                                 upperGardens++;
                             }
                         }
@@ -108,7 +110,7 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         volleyQueue.add(jsonObjectRequest);
     }
 
-    private void addManagedGarden(String name, int id) {
+    private void addManagedGarden(String name, Garden garden) {
         // Set view
         RelativeLayout layout = findViewById(R.id.my_garden_scrollview_layout);
         LayoutInflater layoutInflater = (LayoutInflater)
@@ -122,9 +124,9 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         Button forumButton = managedGardenView.findViewById(R.id.my_garden_managed_forum_button);
         setForumButton(forumButton, 0);
         Button manageButton = managedGardenView.findViewById(R.id.my_garden_managed_manage_button);
-        setManageButton(manageButton, 0);
+        setManageButton(manageButton, garden);
         Button membersButton = managedGardenView.findViewById(R.id.my_garden_managed_members_button);
-        setMembersButton(membersButton, 0);
+        setMembersButton(membersButton, garden);
 
         // Set Garden Name
         TextView textView = managedGardenView.findViewById(R.id.my_garden_managed_name);
@@ -133,7 +135,7 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         layout.addView(managedGardenView);
     }
 
-    private void addGarden(String name, int id) {
+    private void addGarden(String name, Garden garden) {
         // Set view
         RelativeLayout layout = findViewById(R.id.my_garden_scrollview_layout);
         LayoutInflater layoutInflater = (LayoutInflater)
@@ -147,7 +149,7 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         Button forumButton = gardenView.findViewById(R.id.my_garden_forum_button);
         setForumButton(forumButton, 0);
         Button membersButton = gardenView.findViewById(R.id.my_garden_members_button);
-        setMembersButton(membersButton, 0);
+        setMembersButton(membersButton, garden);
 
         // Set Garden Name
         TextView textView = gardenView.findViewById(R.id.my_garden_name);
@@ -170,20 +172,23 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         });
     }
 
-    private void setManageButton(Button manageButton, int id) {
+    private void setManageButton(Button manageButton, Garden garden) {
         manageButton.setOnClickListener(view -> {
             Log.d(TAG, "Clicking Manage Button");
             Intent intent = new Intent(MyGardenYesGardenActivity.this, ManageGardenActivity.class);
             googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+            intent.putExtra("gardenId", garden.getId());
             startActivity(intent);
         });
     }
 
-    private void setMembersButton(Button membersButton, int id) {
+    private void setMembersButton(Button membersButton, Garden garden) {
         membersButton.setOnClickListener(view -> {
             Log.d(TAG, "Clicking Members Button");
             Intent intent = new Intent(MyGardenYesGardenActivity.this, CurrentMembersActivity.class);
             googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+            intent.putExtra("gardenId", garden.getId());
+            intent.putExtra("CameFromMyGardenYes", true);
             startActivity(intent);
         });
     }


### PR DESCRIPTION
Please verify the following changes: 
- MyGarden Member Portal and Manage Garden buttons now dynamically link to the correct garden using gardenId passed as an extra bundle
- Manage garden UI updates the general information fields (contact info, address, etc.) 
- Fixed a bug where traversing MyGarden -> MemberPortal -> Back Button directs to the ManageGarden page instead of MyGarden 

The forum buttons have been left untouched for now. 