### PR TITLE
Member/non-member portal and maps search result location routing

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
@@ -42,7 +42,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
     ArrayList<Role> caretakerList;
     ArrayAdapter<Role> caretakerAdapter;
     int gardenId;
-    boolean cameFromMyGardenYesPage = false;
+//    boolean cameFromMyGardenYesPage = false;
     
     static GoogleProfileInformation googleProfileInformation;
 
@@ -88,17 +88,17 @@ public class CurrentMembersActivity extends AppCompatActivity {
         findViewById(R.id.arrow_back_).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (cameFromMyGardenYesPage) {
-                    Intent myGardenYes = new Intent(CurrentMembersActivity.this, MyGardenYesGardenActivity.class);
-                    googleProfileInformation.loadGoogleProfileInformationToIntent(myGardenYes);
-                    startActivity(myGardenYes);
-                }
-                else {
+//                if (cameFromMyGardenYesPage) {
+//                    Intent myGardenYes = new Intent(CurrentMembersActivity.this, MyGardenYesGardenActivity.class);
+//                    googleProfileInformation.loadGoogleProfileInformationToIntent(myGardenYes);
+//                    startActivity(myGardenYes);
+//                }
+//                else {
                     Intent manageActivity = new Intent(CurrentMembersActivity.this, ManageGardenActivity.class);
                     googleProfileInformation.loadGoogleProfileInformationToIntent(manageActivity);
                     manageActivity.putExtra("gardenId", gardenId);
                     startActivity(manageActivity);
-                }
+//                }
             }
         });
     }
@@ -171,7 +171,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
         if (extras != null) {
             googleProfileInformation = new GoogleProfileInformation(extras);
             gardenId = extras.getInt("gardenId");
-            cameFromMyGardenYesPage = extras.getBoolean("CameFromMyGardenYes");
+//            cameFromMyGardenYesPage = extras.getBoolean("CameFromMyGardenYes");
         }
     }
 

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
@@ -164,7 +164,7 @@ public class GardenInfoMemberActivity extends AppCompatActivity {
                             for (int i = 0; i < fetchedMembers.length(); i++) {
                                 JSONObject roleJsonObject = fetchedMembers.getJSONObject(i);
                                 Role role = new Role(roleJsonObject);
-                                if (Objects.equals(role.getGardenMemberName(), googleProfileInformation.getAccountGoogleName())) {
+                                if (Objects.equals(role.getProfileId(), googleProfileInformation.getAccountUserId())) {
                                     if (role.getRoleNum() == RoleEnum.PLOT_OWNER) {
                                         isPlotOwner = true;
                                         plotOwnerVisibility(View.VISIBLE);

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
@@ -4,18 +4,38 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.android.volley.toolbox.Volley;
+import com.plotpals.client.data.Garden;
+import com.plotpals.client.utils.GoogleProfileInformation;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.w3c.dom.Text;
+
+import java.util.HashMap;
 import java.util.Map;
 
 public class GardenInfoNonMemberActivity extends AppCompatActivity {
     final static String TAG = "GardenInfoNonMemberActivity";
+    Integer gardenId;
+    Garden currentGarden;
+    GoogleProfileInformation googleProfileInformation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_garden_info_non_member);
+        loadExtras();
 
         findViewById(R.id.view_forum_).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -31,13 +51,79 @@ public class GardenInfoNonMemberActivity extends AppCompatActivity {
             }
         });
 
-        findViewById(R.id.arrow_back_).setOnClickListener(new View.OnClickListener() {
+//        findViewById(R.id.arrow_back_).setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View view) {
+//                Toast.makeText(GardenInfoNonMemberActivity.this, "Back Arrow pressed", Toast.LENGTH_SHORT).show();
+//                Intent mapsActivity = new Intent(GardenInfoNonMemberActivity.this, MapsActivity.class);
+//                startActivity(mapsActivity);
+//            }
+//        });
+        findViewById(R.id.arrow_back_).setOnClickListener(view -> finish());
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        requestGardenInfo(gardenId);
+    }
+
+    private void requestGardenInfo(Integer gardenId) {
+        RequestQueue volleyQueue = Volley.newRequestQueue(this);
+        String url = String.format("http://10.0.2.2:8081/gardens/all?gardenId=%s", gardenId);
+
+        Request<?> jsonObjectRequest = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                null,
+
+                (JSONObject response) -> {
+                    try {
+                        Log.d(TAG, "Obtaining garden info");
+                        JSONArray fetchedGarden = (JSONArray)response.get("data");
+                        JSONObject gardenJson = fetchedGarden.getJSONObject(0);
+                        currentGarden = new Garden(gardenJson);
+                        updateGardenOverlayContent(currentGarden);
+
+                    } catch (JSONException e) {
+                        Log.d(TAG, e.toString());
+                    }
+                },
+                (VolleyError e) -> {
+                    Log.d(TAG, e.toString());
+                }
+        ) {
             @Override
-            public void onClick(View view) {
-                Toast.makeText(GardenInfoNonMemberActivity.this, "Back Arrow pressed", Toast.LENGTH_SHORT).show();
-                Intent mapsActivity = new Intent(GardenInfoNonMemberActivity.this, MapsActivity.class);
-                startActivity(mapsActivity);
+            public Map<String, String> getHeaders() {
+                HashMap<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + googleProfileInformation.getAccountIdToken());
+                return headers;
             }
-        });
+        };
+
+        volleyQueue.add(jsonObjectRequest);
+    }
+
+    private void updateGardenOverlayContent(Garden garden) {
+        TextView address = findViewById(R.id.something_r);
+        TextView contactName = findViewById(R.id.contact_nam);
+        TextView contactEmail = findViewById(R.id.name_email_);
+        TextView contactPhone = findViewById(R.id.some_id);
+        TextView gardenName = findViewById(R.id.garden_name);
+
+        address.setText(garden.getAddress());
+        contactName.setText(garden.getGardenOwnerName());
+        contactEmail.setText(garden.getContactEmail());
+        contactPhone.setText(garden.getContactPhoneNumber());
+        gardenName.setText(garden.getGardenName());
+    }
+
+    private void loadExtras() {
+        Bundle extras = getIntent().getExtras();
+
+        if (extras != null) {
+            googleProfileInformation = new GoogleProfileInformation(extras);
+            gardenId = extras.getInt("gardenId");
+        }
     }
 }

--- a/frontend/app/src/main/java/com/plotpals/client/GardenSearchActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenSearchActivity.java
@@ -58,11 +58,6 @@ public class GardenSearchActivity extends AppCompatActivity {
         assert searchView != null;
         searchView.setQueryHint("Search for a Garden");
 
-//        Bundle extras = getIntent().getExtras();
-//        assert extras != null;
-//        String initQuery = extras.getString("initQuery");
-//        searchGarden(initQuery);
-
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String s) {
@@ -113,7 +108,7 @@ public class GardenSearchActivity extends AppCompatActivity {
                     JSONArray fetchedGardens = (JSONArray)response.get("data");
                     if (fetchedGardens.length() > 0) {
                         gardenObjectList.clear();
-                        for (int i =0; i < Math.min(fetchedGardens.length(), 3); i++) {
+                        for (int i =0; i < fetchedGardens.length(); i++) {
                             JSONObject updateGardenObject = fetchedGardens.getJSONObject(i);
                             Garden garden = new Garden(updateGardenObject);
                             gardenObjectList.add(garden);

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -448,10 +448,13 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
 
                         /* Populate taskList with fetched task and notify the TaskListView UI to display the fetched task*/
                         if(fetchedMembers.length() > 0) {
+                            isPlotOwner = false;
+                            isCaretaker = false;
+                            isGardenOwner = false;
                             for (int i = 0; i < fetchedMembers.length(); i++) {
                                 JSONObject roleJsonObject = fetchedMembers.getJSONObject(i);
                                 Role role = new Role(roleJsonObject);
-                                if (Objects.equals(role.getGardenMemberName(), googleProfileInformation.getAccountGoogleName())) {
+                                if (Objects.equals(role.getProfileId(), googleProfileInformation.getAccountUserId())) {
                                     if (role.getRoleNum() == RoleEnum.PLOT_OWNER) {
                                         isPlotOwner = true;
                                     }

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -188,10 +188,10 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
     private void setMembersButton(Button membersButton, Garden garden) {
         membersButton.setOnClickListener(view -> {
             Log.d(TAG, "Clicking Members Button");
-            Intent intent = new Intent(MyGardenYesGardenActivity.this, CurrentMembersActivity.class);
+            Intent intent = new Intent(MyGardenYesGardenActivity.this, GardenInfoMemberActivity.class);
             googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
             intent.putExtra("gardenId", garden.getId());
-            intent.putExtra("CameFromMyGardenYes", true);
+            intent.putExtra("gardenName", garden.getGardenName());
             startActivity(intent);
         });
     }

--- a/frontend/app/src/main/java/com/plotpals/client/utils/gardenBaseAdapter.java
+++ b/frontend/app/src/main/java/com/plotpals/client/utils/gardenBaseAdapter.java
@@ -66,7 +66,8 @@ public class gardenBaseAdapter extends BaseAdapter {
                 Log.d(TAG, String.format("View on map pressed for %s", listGarden.get(i).getGardenName()));
                 Toast.makeText(context, String.format("View on map pressed for %s", listGarden.get(i).getGardenName()), Toast.LENGTH_SHORT).show();
                 Intent mapsIntent = new Intent(searchActivity, MapsActivity.class);
-                mapsIntent.putExtra("moveToSelectedIndex", i);
+                mapsIntent.putExtra("moveToSelectedLat", listGarden.get(i).getLocation().latitude);
+                mapsIntent.putExtra("moveToSelectedLong", listGarden.get(i).getLocation().longitude);
                 searchActivity.startActivity(mapsIntent);
             }
         });

--- a/frontend/app/src/main/res/layout/activity_garden_info_member.xml
+++ b/frontend/app/src/main/res/layout/activity_garden_info_member.xml
@@ -152,11 +152,11 @@
         android:gravity="top"
         android:text="@string/plot_owner"
         android:textAppearance="@style/caretaker"
-        app:layout_constraintBottom_toBottomOf="@+id/rectangle_8"
-        app:layout_constraintEnd_toEndOf="@+id/rectangle_8"
+        app:layout_constraintBottom_toBottomOf="@+id/rectangle_12"
+        app:layout_constraintEnd_toEndOf="@+id/rectangle_12"
         app:layout_constraintHorizontal_bias="0.478"
-        app:layout_constraintStart_toStartOf="@+id/rectangle_8"
-        app:layout_constraintTop_toTopOf="@+id/rectangle_8"
+        app:layout_constraintStart_toStartOf="@+id/rectangle_12"
+        app:layout_constraintTop_toTopOf="@+id/rectangle_12"
         app:layout_constraintVertical_bias="0.538" />
 
     <TextView
@@ -210,7 +210,7 @@
         app:layout_constraintVertical_bias="0.538" />
 
     <View
-        android:id="@+id/rectangle_8"
+        android:id="@+id/rectangle_12"
         android:layout_width="90dp"
         android:layout_height="30dp"
         android:layout_alignParentLeft="true"
@@ -223,6 +223,41 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.272" />
+
+    <View
+        android:id="@+id/rectangle_11"
+        android:layout_width="100dp"
+        android:layout_height="30dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="10dp"
+        android:background="@drawable/rectangle_6"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.461"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.274" />
+
+    <TextView
+        android:id="@+id/garden_owner"
+        android:layout_width="90dp"
+        android:layout_height="15dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="4dp"
+        android:layout_marginBottom="3dp"
+        android:elevation="4dp"
+        android:fontFamily="@font/inter"
+        android:gravity="top"
+        android:text="Garden Owner"
+        android:textAppearance="@style/caretaker"
+        app:layout_constraintBottom_toBottomOf="@+id/rectangle_11"
+        app:layout_constraintEnd_toEndOf="@+id/rectangle_11"
+        app:layout_constraintHorizontal_bias="0.478"
+        app:layout_constraintStart_toStartOf="@+id/rectangle_11"
+        app:layout_constraintTop_toTopOf="@+id/rectangle_11"
+        app:layout_constraintVertical_bias="0.538" />
 
     <TextView
         android:id="@+id/plot"


### PR DESCRIPTION
Bugfixes: 
- MyGardenYesGarden page -> MemberPortal should correctly direct to the member portal page instead of the current members page
- maps should now correctly load all of the markers from the gardens fetched from the database 
- maps search results should now display all gardens instead of minimum 3
- clicking view location in the search results UI should direct to the correct location specified by the address

New: 
- selecting a map marker to a garden that you haven't joined should now display the non-member garden info page (join and view forum board buttons haven't been implemented yet) 
- the temporary button accessed in the member portal still exists for ease of access

![image](https://github.com/ngjstn/plot-pals/assets/89366060/3e62c102-6b4b-4e13-b0ad-3806ce22641c)
