### PR TITLE
Routing to forum board from garden disc and info pages

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/ForumBoardMainActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ForumBoardMainActivity.java
@@ -60,12 +60,13 @@ public class ForumBoardMainActivity extends NavBarActivity {
         name.setText(currentGardenName);
 
         ImageView arrow = findViewById(R.id.forum_board_arrow);
-        arrow.setOnClickListener(view -> {
-            Log.d(TAG, "Clicking Back Arrow");
-            Intent mapsIntent = new Intent(ForumBoardMainActivity.this, MyGardenYesGardenActivity.class);
-            googleProfileInformation.loadGoogleProfileInformationToIntent(mapsIntent);
-            startActivity(mapsIntent);
-        });
+        arrow.setOnClickListener(view -> finish());
+//        arrow.setOnClickListener(view -> {
+//            Log.d(TAG, "Clicking Back Arrow");
+//            Intent myGardenIntent = new Intent(ForumBoardMainActivity.this, MyGardenYesGardenActivity.class);
+//            googleProfileInformation.loadGoogleProfileInformationToIntent(myGardenIntent);
+//            startActivity(myGardenIntent);
+//        });
 
         ImageView plus = findViewById(R.id.forum_board_plus);
         plus.setOnClickListener(view -> {

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
@@ -69,6 +69,11 @@ public class GardenInfoMemberActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Toast.makeText(GardenInfoMemberActivity.this, "Forum Board pressed", Toast.LENGTH_SHORT).show();
+                Intent forumBoard = new Intent(GardenInfoMemberActivity.this, ForumBoardMainActivity.class);
+                googleProfileInformation.loadGoogleProfileInformationToIntent(forumBoard);
+                forumBoard.putExtra("gardenId", gardenId);
+                forumBoard.putExtra("gardenName", gardenName);
+                startActivity(forumBoard);
             }
         });
 

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
@@ -48,6 +48,11 @@ public class GardenInfoNonMemberActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 Toast.makeText(GardenInfoNonMemberActivity.this, "View Forum Board pressed", Toast.LENGTH_SHORT).show();
+                Intent forumBoard = new Intent(GardenInfoNonMemberActivity.this, ForumBoardMainActivity.class);
+                googleProfileInformation.loadGoogleProfileInformationToIntent(forumBoard);
+                forumBoard.putExtra("gardenId", gardenId);
+                forumBoard.putExtra("gardenName", currentGarden.getGardenName());
+                startActivity(forumBoard);
             }
         });
 

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -127,7 +127,11 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
             @Override
             public void onClick(View view) {
                 Log.d(TAG, "Forum board button pressed");
-                Toast.makeText(MapsActivity.this, "View Forum Board pressed", Toast.LENGTH_SHORT).show();
+                Intent forumBoard = new Intent(MapsActivity.this, ForumBoardMainActivity.class);
+                googleProfileInformation.loadGoogleProfileInformationToIntent(forumBoard);
+                forumBoard.putExtra("gardenId", currentGardenSelected.getId());
+                forumBoard.putExtra("gardenName", currentGardenSelected.getGardenName());
+                startActivity(forumBoard);
             }
         });
 


### PR DESCRIPTION
Small routing changes. Should be able to now access the forum board from garden discovery and garden info pages: 

![image](https://github.com/ngjstn/plot-pals/assets/89366060/20f87e5a-af81-464c-8416-1938c4bc11ba)

![image](https://github.com/ngjstn/plot-pals/assets/89366060/a4ec76d8-c44c-4730-98df-cb73a027a0d9)

Result page:

![image](https://github.com/ngjstn/plot-pals/assets/89366060/e38be582-f79b-490e-b2eb-96100828b63d)
