### PR TITLE
Blank map entry routing fix for null location

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/GardenSearchActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenSearchActivity.java
@@ -35,7 +35,7 @@ public class GardenSearchActivity extends AppCompatActivity {
 //    ArrayList<String> gardenList = new ArrayList<String>(Arrays.asList("Garden 1", "Garden 2", "Garden 3", "Garden 4", "Garden 5"));
     private List<Garden> gardenObjectList = new ArrayList<>();
     int[] gardenImages = {R.drawable.image_rec, R.drawable.image_rec, R.drawable.image_rec, R.drawable.image_rec, R.drawable.image_rec};
-    static GoogleProfileInformation googleProfileInformation;
+    GoogleProfileInformation googleProfileInformation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,7 +46,7 @@ public class GardenSearchActivity extends AppCompatActivity {
         loadProfileInfo();
         requestGardens();
         listView = (ListView) findViewById(R.id.garden_list);
-        gardenBaseAdapter arrayAdapter = new gardenBaseAdapter(getApplicationContext(), gardenObjectList, gardenImages, GardenSearchActivity.this);
+        gardenBaseAdapter arrayAdapter = new gardenBaseAdapter(getApplicationContext(), gardenObjectList, gardenImages, GardenSearchActivity.this, googleProfileInformation);
         listView.setAdapter(arrayAdapter);
     }
 
@@ -90,7 +90,7 @@ public class GardenSearchActivity extends AppCompatActivity {
             findViewById(R.id.try_again_text).setVisibility(View.VISIBLE);
         }
 
-        gardenBaseAdapter arrayAdapter = new gardenBaseAdapter(getApplicationContext(), gardensSearched, gardenImages, GardenSearchActivity.this);
+        gardenBaseAdapter arrayAdapter = new gardenBaseAdapter(getApplicationContext(), gardensSearched, gardenImages, GardenSearchActivity.this, googleProfileInformation);
         listView.setAdapter(arrayAdapter);
     }
 

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -48,6 +48,7 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MapStyleOptions;
 import com.google.android.gms.maps.model.Marker;
@@ -190,7 +191,6 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         LatLng currentLocation = new LatLng(locationLat, locationLong);
         drawCurrentLocationMarker();
         requestGardens();
-//        mapsMarker = mMap.addMarker(new MarkerOptions().position(currentLocation).title(String.format("Marker in %s", locationCityName)));
         mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(currentLocation, 15));
 
         googleMap.setOnMarkerClickListener(this);
@@ -214,25 +214,13 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
         locationLat = location.getLatitude();
         locationLong = location.getLongitude();
 
-        // parse for city name using current location
-//        Geocoder geocoder = new Geocoder(this, Locale.getDefault());
-//        try {
-//            List<Address> addresses = geocoder.getFromLocation(location.getLatitude(), location.getLongitude(), 1);
-//            locationCityName = addresses.get(0).getLocality();
-//            Log.d(TAG, String.format("Current City: %s, Lat: %f, Long: %f", locationCityName, locationLat, locationLong));
-//        } catch (IOException e) {
-//            Log.d(TAG, String.format("Can't find Geocoder locality: %f", e));
-//            //            throw new RuntimeException(e);
-//        }
-
         Log.d(TAG, String.format("Lat: %f, Long: %f", locationLat, locationLong));
         LatLng currentLocation = new LatLng(locationLat, locationLong);
         // marker is stuck on default location (0,0); move to current location
-        if (mapsMarker.getPosition().equals(new LatLng(0, 0))) {
+        if (mapsMarker.getPosition().equals(new LatLng(0, 0)) || mMap.getCameraPosition().target.equals(new LatLng(0,0))) {
             mMap.moveCamera(CameraUpdateFactory.newLatLng(currentLocation));
         }
         mapsMarker.setPosition(currentLocation);
-//        mapsMarker.setTitle(String.format("Marker in %s", locationCityName));
     }
 
 
@@ -352,7 +340,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     private void loadExtras() {
         Bundle extras = getIntent().getExtras();
 
-        if (extras != null && googleProfileInformation == null) {
+        if (extras != null) {
             googleProfileInformation = new GoogleProfileInformation(extras);
         }
     }
@@ -415,7 +403,9 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                             double latitude = extras.getDouble("moveToSelectedLat");
                             double longitude = extras.getDouble("moveToSelectedLong");
                             LatLng locationFromSearch = new LatLng(latitude, longitude);
-                            mMap.moveCamera(CameraUpdateFactory.newLatLng(locationFromSearch));
+                            if (!locationFromSearch.equals(new LatLng(0,0))) {
+                                mMap.moveCamera(CameraUpdateFactory.newLatLng(locationFromSearch));
+                            }
                         }
                     }
                 } catch (JSONException e) {

--- a/frontend/app/src/main/java/com/plotpals/client/utils/gardenBaseAdapter.java
+++ b/frontend/app/src/main/java/com/plotpals/client/utils/gardenBaseAdapter.java
@@ -23,12 +23,14 @@ public class gardenBaseAdapter extends BaseAdapter {
     List<Garden> listGarden;
     int listImages[];
     GardenSearchActivity searchActivity;
+    GoogleProfileInformation googleProfileInformation;
 
-    public gardenBaseAdapter(Context ctx, List<Garden> garden, int[] images, GardenSearchActivity activity) {
+    public gardenBaseAdapter(Context ctx, List<Garden> garden, int[] images, GardenSearchActivity activity, GoogleProfileInformation googleProfileInformation) {
         this.context = ctx;
         this.listGarden = garden;
         this.listImages = images;
         this.searchActivity = activity;
+        this.googleProfileInformation = googleProfileInformation;
     }
     @Override
     public int getCount() {
@@ -66,6 +68,7 @@ public class gardenBaseAdapter extends BaseAdapter {
                 Log.d(TAG, String.format("View on map pressed for %s", listGarden.get(i).getGardenName()));
                 Toast.makeText(context, String.format("View on map pressed for %s", listGarden.get(i).getGardenName()), Toast.LENGTH_SHORT).show();
                 Intent mapsIntent = new Intent(searchActivity, MapsActivity.class);
+                googleProfileInformation.loadGoogleProfileInformationToIntent(mapsIntent);
                 mapsIntent.putExtra("moveToSelectedLat", listGarden.get(i).getLocation().latitude);
                 mapsIntent.putExtra("moveToSelectedLong", listGarden.get(i).getLocation().longitude);
                 searchActivity.startActivity(mapsIntent);


### PR DESCRIPTION
There was logic onStart in the map activity that routed to a location determined by the search results. Certain scenarios caused this value to be null, which defaulted the map camera position to (0,0), making it look like the map was broken when really it was just pointing to the middle of some ocean. 

Please try to break the map, specifically by entering and leaving the map activity multiple times. Verify that viewing the map from the search results page correctly directs you to the garden location marker. 