### PR TITLE
Leave garden functionality 

### DIFF
--- a/backend/controllers/rolesController.js
+++ b/backend/controllers/rolesController.js
@@ -62,9 +62,23 @@ const updateRole = async (req, res, next) => {
   }
 };
 
+const deleteRole = async (req, res, next) => {
+  const { profileId, gardenId } = req.params;
+
+  const sql = `DELETE FROM roles WHERE profileId=? AND gardenId=?`;
+
+  try {
+    const queryResults = await database.query(sql, [profileId, gardenId]);
+    return res.json({ success: queryResults[0].affectedRows > 0 });
+  } catch (err) {
+    return next(err);
+  }
+};
+
 module.exports = {
   getAllRoles,
   getRolesForAuthenticatedUser,
   addRole,
   updateRole,
+  deleteRole,
 };

--- a/backend/controllers/rolesController.js
+++ b/backend/controllers/rolesController.js
@@ -66,7 +66,42 @@ const updateRole = async (req, res, next) => {
 const deleteRole = async (req, res, next) => {
   const { profileId, gardenId } = req.params;
 
-  const sql = `DELETE FROM roles WHERE profileId=? AND gardenId=?`;
+  let sql;
+
+  // Delete tasks from user
+  sql = `
+  DELETE tasks FROM tasks
+  INNER JOIN posts
+  ON posts.taskId = tasks.taskId
+  WHERE posts.assignerId = ? AND posts.postGardenId = ?;`;
+  try {
+    await database.query(sql, [profileId, gardenId]);
+  } catch (err) {
+    return next(err);
+  }
+
+  // Delete posts from user
+  sql = `
+  DELETE FROM posts
+  WHERE assignerId = ? AND postGardenId = ?;`;
+  try {
+    await database.query(sql, [profileId, gardenId]);
+  } catch (err) {
+    return next(err);
+  }
+
+  // Delete plots from user
+  sql = `
+  DELETE FROM plots
+  WHERE plotOwnerId = ? AND gardenId = ?;`;
+  try {
+    await database.query(sql, [profileId, gardenId]);
+  } catch (err) {
+    return next(err);
+  }
+
+  // Remove user from garden
+  sql = `DELETE FROM roles WHERE profileId=? AND gardenId=?`;
 
   try {
     const queryResults = await database.query(sql, [profileId, gardenId]);

--- a/backend/routers/rolesRouter.js
+++ b/backend/routers/rolesRouter.js
@@ -1,5 +1,11 @@
 const express = require('express');
-const { getRolesForAuthenticatedUser, getAllRoles, addRole, updateRole } = require('../controllers/rolesController');
+const {
+  getRolesForAuthenticatedUser,
+  getAllRoles,
+  addRole,
+  updateRole,
+  deleteRole,
+} = require('../controllers/rolesController');
 
 const authMiddleware = require('../authMiddleware');
 
@@ -13,5 +19,7 @@ router.get('/all', authMiddleware, getAllRoles);
 router.post('/', authMiddleware, addRole);
 
 router.put('/:profileId/:gardenId', authMiddleware, updateRole);
+
+router.delete('/:profileId/:gardenId', authMiddleware, deleteRole);
 
 module.exports = router;

--- a/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MyGardenYesGardenActivity.java
@@ -155,8 +155,7 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
         TextView leaveButton = gardenView.findViewById(R.id.my_garden_leave);
         leaveButton.setVisibility(View.GONE);
         leaveButton.setOnClickListener(view -> {
-            // TODO: leave the garden, make garden disappear
-            Toast.makeText(MyGardenYesGardenActivity.this, "Left Garden", Toast.LENGTH_SHORT).show();
+            leaveGarden(garden.getId());
         });
         ImageView dots = gardenView.findViewById(R.id.my_garden_more_dots);
         dots.setOnClickListener(view -> leaveButton.setVisibility(View.VISIBLE));
@@ -203,6 +202,42 @@ public class MyGardenYesGardenActivity extends NavBarActivity {
             intent.putExtra("gardenName", garden.getGardenName());
             startActivity(intent);
         });
+    }
+
+    private void leaveGarden(int gardenId) {
+        RequestQueue volleyQueue = Volley.newRequestQueue(this);
+        String url = "http://10.0.2.2:8081/roles/" + googleProfileInformation.getAccountUserId() + "/" + gardenId;
+        Request<?> jsonObjectRequest = new JsonObjectRequest(
+                Request.Method.DELETE,
+                url,
+                null,
+                (JSONObject response) -> {
+                    try {
+                        Log.d(TAG, "Attempted removal of user from garden");
+                        boolean leaveGardenIsSuccessful = (boolean)response.get("success");
+                        if (leaveGardenIsSuccessful) {
+                            // Restart activity
+                            finish();
+                            startActivity(getIntent());
+                        } else {
+                            Log.d(TAG, "Removal of user from garden was not successful");
+                        }
+                    } catch (JSONException e) {
+                        Log.d(TAG, e.toString());
+                    }
+                },
+                (VolleyError e) -> {
+                    Log.d(TAG, e.toString());
+                }
+        ) {
+            @Override
+            public Map<String, String> getHeaders() {
+                HashMap<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + googleProfileInformation.getAccountIdToken());
+                return headers;
+            }
+        };
+        volleyQueue.add(jsonObjectRequest);
     }
 
 }


### PR DESCRIPTION
Added functionality to "Leave Garden" button in "My Garden" page
![image](https://github.com/ngjstn/plot-pals/assets/69666141/b8348f73-79b1-4ae3-be7a-795828e9b49b)

Leaving garden will now:
1. Remove all plots, posts and tasks entries associated to removed user
2. Remove completed tasks (that has not been given feedback) assigned to removed user
3. Updates uncompleted tasks assigned to removed user so that it can be taken by other users


New API endpoint that handles leaving gardens: 
`DELETE /:profileId/:gardenId `

