### PR TITLE
various UI changes

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/CurrentMembersActivity.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CurrentMembersActivity extends AppCompatActivity {
+public class CurrentMembersActivity extends NavBarActivity {
     final static String TAG = "CurrentMembersActivity";
     ListView plotOwnerListView;
     ArrayList<Role> plotOwnerList;
@@ -55,6 +55,7 @@ public class CurrentMembersActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_current_members);
+        activateNavBar();
         plotsList = new ArrayList<>();
         plotOwnerList = new ArrayList<>();
         plotOwnerListView = findViewById(R.id.plot_owner_list_view);

--- a/frontend/app/src/main/java/com/plotpals/client/ForumBoardMainActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ForumBoardMainActivity.java
@@ -67,12 +67,19 @@ public class ForumBoardMainActivity extends NavBarActivity {
 
         ImageView arrow = findViewById(R.id.forum_board_arrow);
         arrow.setOnClickListener(view -> finish());
-//        arrow.setOnClickListener(view -> {
-//            Log.d(TAG, "Clicking Back Arrow");
-//            Intent myGardenIntent = new Intent(ForumBoardMainActivity.this, MyGardenYesGardenActivity.class);
-//            googleProfileInformation.loadGoogleProfileInformationToIntent(myGardenIntent);
-//            startActivity(myGardenIntent);
-//        });
+
+        View greyScreenOverlay = findViewById(R.id.plus_grey_screen);
+        greyScreenOverlay.setVisibility(View.GONE);
+
+        greyScreenOverlay.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if (greyScreenOverlay.getVisibility() == View.VISIBLE) {
+                    newTaskText.setVisibility(View.GONE);
+                    greyScreenOverlay.setVisibility(View.GONE);
+                }
+            }
+        });
 
         ImageView plus = findViewById(R.id.forum_board_plus);
         plus.setOnClickListener(view -> {
@@ -81,6 +88,7 @@ public class ForumBoardMainActivity extends NavBarActivity {
             // We disable posts for now
             // newPostText.setVisibility(newPostText.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
             newTaskText.setVisibility(newTaskText.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+            greyScreenOverlay.setVisibility(greyScreenOverlay.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
         });
 
         newPostText.setOnClickListener(view -> {
@@ -124,6 +132,8 @@ public class ForumBoardMainActivity extends NavBarActivity {
         super.onStart();
         requestMembers(currentGardenId);
         loadPosts();
+        findViewById(R.id.forum_board_new_task).setVisibility(View.GONE);
+        findViewById(R.id.plus_grey_screen).setVisibility(View.GONE);
     }
 
     private void loadPosts() {

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class GardenInfoMemberActivity extends AppCompatActivity {
+public class GardenInfoMemberActivity extends NavBarActivity {
     final static String TAG = "GardenInfoMemberActivity";
     ArrayList<Post> tasksList;
     ListView TasksListView;
@@ -49,6 +49,7 @@ public class GardenInfoMemberActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_garden_info_member);
         loadExtras();
+        activateNavBar();
 
         TasksListView = findViewById(R.id.tasks_list_view);
         tasksList = new ArrayList<Post>();

--- a/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ManageGardenActivity.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ManageGardenActivity extends AppCompatActivity {
+public class ManageGardenActivity extends NavBarActivity {
     final static String TAG = "ManageGardenActivity";
     static GoogleProfileInformation googleProfileInformation;
     ArrayList<String> memberNameList;
@@ -43,6 +43,7 @@ public class ManageGardenActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_manage_garden);
         loadExtras();
+        activateNavBar();
 
         memberNameList = new ArrayList<>();
 

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -327,7 +327,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
     }
 
     private void drawGardenLocationMarker(Garden garden) {
-        Drawable greenMarker = getResources().getDrawable(R.drawable.location_marker_green);
+        Drawable greenMarker = getResources().getDrawable(R.drawable.plant_house);
         BitmapDescriptor markerIcon = getMarkerIconFromDrawable(greenMarker);
 
         Marker marker = mMap.addMarker(new MarkerOptions()

--- a/frontend/app/src/main/res/drawable/my_garden_button.xml
+++ b/frontend/app/src/main/res/drawable/my_garden_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="131dp"
+    android:height="30dp"
+    android:viewportWidth="131"
+    android:viewportHeight="30"
+    >
+    <group>
+        <clip-path
+            android:pathData="M10 0H121C126.523 0 131 4.47715 131 10V20C131 25.5228 126.523 30 121 30H10C4.47715 30 0 25.5228 0 20V10C0 4.47715 4.47715 0 10 0Z"
+            />
+        <path
+            android:pathData="M0 0V30H131V0"
+            android:fillColor="#B5B5B5"
+            />
+    </group>
+</vector>

--- a/frontend/app/src/main/res/drawable/my_garden_image.xml
+++ b/frontend/app/src/main/res/drawable/my_garden_image.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="119dp"
+    android:height="71dp"
+    android:viewportWidth="119"
+    android:viewportHeight="71"
+    >
+    <group>
+        <clip-path
+            android:pathData="M10 0H109C114.523 0 119 4.47715 119 10V61C119 66.5228 114.523 71 109 71H10C4.47715 71 0 66.5228 0 61V10C0 4.47715 4.47715 0 10 0Z"
+            />
+        <path
+            android:pathData="M0 0V71H119V0"
+            android:fillColor="#ABABAB"
+            />
+    </group>
+</vector>

--- a/frontend/app/src/main/res/drawable/my_garden_manage_image.xml
+++ b/frontend/app/src/main/res/drawable/my_garden_manage_image.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="119dp"
+    android:height="112dp"
+    android:viewportWidth="119"
+    android:viewportHeight="112"
+    >
+    <group>
+        <clip-path
+            android:pathData="M10 0H109C114.523 0 119 4.47715 119 10V102C119 107.523 114.523 112 109 112H10C4.47715 112 0 107.523 0 102V10C0 4.47715 4.47715 0 10 0Z"
+            />
+        <path
+            android:pathData="M0 0V112H119V0"
+            android:fillColor="#ABABAB"
+            />
+    </group>
+</vector>

--- a/frontend/app/src/main/res/drawable/plant_house.xml
+++ b/frontend/app/src/main/res/drawable/plant_house.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M1,10.5l11,-9l11,9"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+  <path
+      android:pathData="M20,7.5l0,15l-16,0l0,-15"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+  <path
+      android:pathData="M22,22.5L2,22.5"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+  <path
+      android:pathData="M7,10.5h0.77A4.23,4.23 0,0 1,12 14.73v0.77a0,0 0,0 1,0 0h-0.77A4.23,4.23 0,0 1,7 11.27V10.5A0,0 0,0 1,7 10.5Z"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+  <path
+      android:pathData="M12.77,16.5L12,16.5a0,0 0,0 1,-0 -0l-0,-0.77a4.23,4.23 0,0 1,4.23 -4.23L17,11.5a0,0 0,0 1,-0 -0l-0,0.77A4.23,4.23 0,0 1,12.77 16.5Z"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+  <path
+      android:pathData="M12,21.5L12,14.5"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#8fcf5e"/>
+</vector>

--- a/frontend/app/src/main/res/layout/activity_current_members.xml
+++ b/frontend/app/src/main/res/layout/activity_current_members.xml
@@ -6,6 +6,8 @@
     android:layout_height="match_parent"
     tools:context=".CurrentMembersActivity">
 
+    <include layout="@layout/activity_nav_bar"/>
+
     <TextView
         android:id="@+id/garden_name"
         android:layout_width="325dp"

--- a/frontend/app/src/main/res/layout/activity_forum_board_main.xml
+++ b/frontend/app/src/main/res/layout/activity_forum_board_main.xml
@@ -57,6 +57,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="36dp"
+        android:elevation="5dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
@@ -65,6 +66,21 @@
         app:layout_constraintVertical_bias="0.114"
         app:srcCompat="@drawable/add" />
 
+    <View
+        android:id="@+id/plus_grey_screen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:background="#75FFFFFF"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="@+id/include4"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0" />
+
     <TextView
         android:id="@+id/forum_board_new_post"
         android:layout_width="141dp"
@@ -72,6 +88,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginTop="16dp"
+        android:elevation="5dp"
         android:gravity="right"
         android:text="New Post"
         android:textAppearance="@style/label_text_big"
@@ -88,6 +105,7 @@
         android:layout_height="25dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:elevation="5dp"
         android:gravity="right"
         android:text="New Task"
         android:textAppearance="@style/label_text_big"

--- a/frontend/app/src/main/res/layout/activity_forum_board_main.xml
+++ b/frontend/app/src/main/res/layout/activity_forum_board_main.xml
@@ -69,7 +69,7 @@
     <View
         android:id="@+id/plus_grey_screen"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="670dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:background="#75FFFFFF"

--- a/frontend/app/src/main/res/layout/activity_garden_info_member.xml
+++ b/frontend/app/src/main/res/layout/activity_garden_info_member.xml
@@ -6,6 +6,8 @@
     android:layout_height="match_parent"
     tools:context=".GardenInfoNonMemberActivity">
 
+    <include layout="@layout/activity_nav_bar"/>
+
     <TextView
         android:id="@+id/garden_name"
         android:layout_width="325dp"
@@ -62,6 +64,7 @@
         app:layout_constraintTop_toTopOf="@+id/rectangle_2"
         app:layout_constraintVertical_bias="0.583" />
 
+
     <Button
         android:id="@+id/rectangle_2"
         android:layout_width="120dp"
@@ -71,11 +74,10 @@
         android:background="@drawable/rectangle_6"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.883"
+        app:layout_constraintHorizontal_bias="0.876"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.923" />
-
+        app:layout_constraintVertical_bias="0.869" />
 
     <View
         android:id="@+id/rectangle_4"
@@ -270,10 +272,23 @@
         android:background="#D9D9D9"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.521"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.433" />
+
+    <ListView
+        android:id="@+id/tasks_list_view"
+        android:layout_width="340dp"
+        android:layout_height="260dp"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.492"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.455" />
+        app:layout_constraintVertical_bias="0.675" />
 
     <TextView
         android:id="@+id/my_tasks"
@@ -290,19 +305,6 @@
         app:layout_constraintHorizontal_bias="0.117"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.412" />
-
-    <ListView
-        android:id="@+id/tasks_list_view"
-        android:layout_width="340dp"
-        android:layout_height="260dp"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.492"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.709" />
+        app:layout_constraintVertical_bias="0.389" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_manage_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_manage_garden.xml
@@ -6,6 +6,8 @@
     android:layout_height="match_parent"
     tools:context=".ManageGardenActivity">
 
+    <include layout="@layout/activity_nav_bar"/>
+
     <View
         android:id="@+id/image_rec"
         android:layout_width="115dp"
@@ -40,13 +42,14 @@
         android:layout_height="24dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:layout_marginStart="5dp"
         android:fontFamily="@font/inter_semibold"
         android:gravity="top"
         android:text="@string/general_inf"
         android:textAppearance="@style/general_inf"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.236"
+        app:layout_constraintHorizontal_bias="0.271"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.131" />
@@ -123,7 +126,7 @@
     <TextView
         android:id="@+id/name_email_"
         android:layout_width="84dp"
-        android:layout_height="12dp"
+        android:layout_height="16dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
         android:layout_marginBottom="10dp"
@@ -209,6 +212,7 @@
         android:layout_height="17dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:layout_marginStart="7dp"
         android:fontFamily="@font/inter"
         android:gravity="top"
         android:text="@string/something_r"

--- a/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_garden.xml
@@ -18,28 +18,30 @@
 
     <TextView
         android:id="@+id/my_garden_name"
-        android:layout_width="280dp"
+        android:layout_width="225dp"
         android:layout_height="32dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:layout_marginStart="15dp"
+        android:layout_marginBottom="20dp"
         android:autoSizeTextType="uniform"
         android:gravity="top"
         android:text="@string/garden_name"
         android:textAppearance="@style/label_text_big"
         app:layout_constraintBottom_toBottomOf="@+id/view"
         app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.423"
+        app:layout_constraintHorizontal_bias="0.097"
         app:layout_constraintStart_toStartOf="@+id/view"
         app:layout_constraintTop_toTopOf="@+id/view"
-        app:layout_constraintVertical_bias="0.142" />
+        app:layout_constraintVertical_bias="0.141" />
 
     <Button
         android:id="@+id/my_garden_members_button"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
+        android:layout_width="131dp"
+        android:layout_height="30dp"
         android:autoSizeTextType="uniform"
-        android:text="Member Portal"
         android:textAppearance="@style/basic_text"
+        android:background="@drawable/my_garden_button"
         app:layout_constraintBottom_toBottomOf="@+id/view"
         app:layout_constraintEnd_toEndOf="@+id/view"
         app:layout_constraintHorizontal_bias="0.917"
@@ -47,27 +49,63 @@
         app:layout_constraintTop_toTopOf="@+id/view"
         app:layout_constraintVertical_bias="0.49" />
 
+    <TextView
+        android:id="@+id/member_port"
+        android:layout_width="100dp"
+        android:layout_height="17dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="2dp"
+        android:elevation="5dp"
+        android:text="Member Portal"
+        android:textAlignment="center"
+        android:textAppearance="@style/caretaker"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_members_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_members_button"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_members_button"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_members_button" />
+
     <Button
         android:id="@+id/my_garden_forum_button"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
+        android:layout_width="131dp"
+        android:layout_height="30dp"
         android:layout_marginBottom="16dp"
         android:autoSizeTextType="uniform"
-        android:text="Forum Board"
+        android:background="@drawable/my_garden_button"
         android:textAppearance="@style/basic_text"
         app:layout_constraintBottom_toBottomOf="@+id/view"
         app:layout_constraintEnd_toEndOf="@+id/view"
-        app:layout_constraintHorizontal_bias="0.917"
+        app:layout_constraintHorizontal_bias="0.914"
         app:layout_constraintStart_toStartOf="@+id/view"
         app:layout_constraintTop_toBottomOf="@+id/my_garden_members_button"
-        app:layout_constraintVertical_bias="0.333" />
+        app:layout_constraintVertical_bias="0.916" />
+
+    <TextView
+        android:id="@+id/forum_board_text"
+        android:layout_width="100dp"
+        android:layout_height="17dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="2dp"
+        android:elevation="5dp"
+        android:text="Forum Board"
+        android:textAlignment="center"
+        android:textAppearance="@style/caretaker"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_forum_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_forum_button"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_forum_button"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_forum_button" />
 
     <ImageView
         android:id="@+id/my_garden_more_dots"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="5dp"
         app:layout_constraintBottom_toBottomOf="@+id/my_garden_name"
-        app:layout_constraintEnd_toEndOf="@+id/my_garden_name"
+        app:layout_constraintEnd_toEndOf="@+id/view"
         app:srcCompat="@drawable/more_dots" />
 
     <TextView
@@ -76,12 +114,27 @@
         android:layout_height="25dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:layout_marginEnd="4dp"
         android:gravity="right"
         android:text="Leave Garden"
         android:textAppearance="@style/label_text"
         android:textColor="#C50000"
         app:layout_constraintBottom_toTopOf="@+id/my_garden_more_dots"
         app:layout_constraintEnd_toEndOf="@+id/my_garden_name" />
+
+    <View
+        android:id="@+id/rectangle_2"
+        android:layout_width="119dp"
+        android:layout_height="71dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:background="@drawable/my_garden_image"
+        app:layout_constraintBottom_toBottomOf="@+id/view"
+        app:layout_constraintEnd_toEndOf="@+id/view"
+        app:layout_constraintHorizontal_bias="0.101"
+        app:layout_constraintStart_toStartOf="@+id/view"
+        app:layout_constraintTop_toTopOf="@+id/view"
+        app:layout_constraintVertical_bias="0.767" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_managed_garden.xml
@@ -18,24 +18,41 @@
 
     <Button
         android:id="@+id/my_garden_managed_manage_button"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:layout_marginBottom="20dp"
+        android:layout_width="131dp"
+        android:layout_height="30dp"
+        android:layout_marginBottom="23dp"
         android:autoSizeTextType="uniform"
-        android:text="Manage Garden"
+        android:background="@drawable/my_garden_button"
         android:textAppearance="@style/basic_text"
         app:layout_constraintBottom_toBottomOf="@+id/my_garden_big_view"
         app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
         app:layout_constraintHorizontal_bias="0.914"
         app:layout_constraintStart_toStartOf="@+id/my_garden_big_view" />
 
+    <TextView
+        android:id="@+id/manage_garden_text"
+        android:layout_width="110dp"
+        android:layout_height="18dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="2dp"
+        android:elevation="5dp"
+        android:text="Manage Garden"
+        android:textAlignment="center"
+        android:textAppearance="@style/caretaker"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_managed_manage_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_managed_manage_button"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_managed_manage_button"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_managed_manage_button" />
+
     <Button
         android:id="@+id/my_garden_managed_forum_button"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
+        android:layout_width="131dp"
+        android:layout_height="30dp"
         android:autoSizeTextType="uniform"
-        android:text="Forum Board"
         android:textAppearance="@style/basic_text"
+        android:background="@drawable/my_garden_button"
         app:layout_constraintBottom_toTopOf="@+id/my_garden_managed_manage_button"
         app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
         app:layout_constraintHorizontal_bias="0.914"
@@ -43,13 +60,30 @@
         app:layout_constraintTop_toBottomOf="@+id/my_garden_managed_members_button"
         app:layout_constraintVertical_bias="0.478" />
 
+    <TextView
+        android:id="@+id/forum_board_text"
+        android:layout_width="100dp"
+        android:layout_height="17dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="2dp"
+        android:elevation="5dp"
+        android:text="Forum Board"
+        android:textAlignment="center"
+        android:textAppearance="@style/caretaker"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_managed_forum_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_managed_forum_button"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_managed_forum_button"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_managed_forum_button" />
+
     <Button
         android:id="@+id/my_garden_managed_members_button"
-        android:layout_width="125dp"
-        android:layout_height="36dp"
-        android:layout_marginTop="48dp"
+        android:layout_width="131dp"
+        android:layout_height="30dp"
+        android:layout_marginTop="52dp"
         android:autoSizeTextType="uniform"
-        android:text="Member Portal"
+        android:background="@drawable/my_garden_button"
         android:textAppearance="@style/basic_text"
         app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
         app:layout_constraintHorizontal_bias="0.914"
@@ -57,11 +91,30 @@
         app:layout_constraintTop_toTopOf="@+id/my_garden_big_view" />
 
     <TextView
+        android:id="@+id/member_port"
+        android:layout_width="100dp"
+        android:layout_height="17dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="2dp"
+        android:elevation="5dp"
+        android:text="Member Portal"
+        android:textAlignment="center"
+        android:textAppearance="@style/caretaker"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_managed_members_button"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_managed_members_button"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_managed_members_button"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_managed_members_button" />
+
+    <TextView
         android:id="@+id/my_garden_managed_name"
         android:layout_width="280dp"
         android:layout_height="32dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
+        android:layout_marginStart="15dp"
+        android:layout_marginBottom="20dp"
         android:autoSizeTextType="uniform"
         android:gravity="top"
         android:text="@string/garden_name"
@@ -72,6 +125,20 @@
         app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
         app:layout_constraintTop_toTopOf="@+id/my_garden_big_view"
         app:layout_constraintVertical_bias="0.103" />
+
+    <View
+        android:id="@+id/image"
+        android:layout_width="119dp"
+        android:layout_height="112dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:background="@drawable/my_garden_manage_image"
+        app:layout_constraintBottom_toBottomOf="@+id/my_garden_big_view"
+        app:layout_constraintEnd_toEndOf="@+id/my_garden_big_view"
+        app:layout_constraintHorizontal_bias="0.101"
+        app:layout_constraintStart_toStartOf="@+id/my_garden_big_view"
+        app:layout_constraintTop_toTopOf="@+id/my_garden_big_view"
+        app:layout_constraintVertical_bias="0.693" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
+++ b/frontend/app/src/main/res/layout/activity_my_garden_yes_garden.xml
@@ -28,7 +28,7 @@
         android:layout_height="40dp"
         android:layout_alignParentStart="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="36dp"
+        android:layout_marginStart="43dp"
         android:layout_marginTop="76dp"
         android:fontFamily="@font/inter_bold"
         android:gravity="top"
@@ -39,10 +39,10 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="530dp"
+        android:layout_height="525dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="@+id/include3"
-        app:layout_constraintVertical_bias="0.661"
+        app:layout_constraintVertical_bias="0.679"
         tools:layout_editor_absoluteX="0dp">
 
         <RelativeLayout


### PR DESCRIPTION
frontend UI changes: 
- Garden Discovery map markers uses plant houses instead of generic markers for gardens (current location still uses default red marker) 
- updated scroll view for My Gardens page list to use correct button, image, and text views 
- Homepage now correctly shows plotpals display name instead of google id name 
- added navbar to Manage Garden and Current Members pages 
- clicking the "New Task" plus button in the Forum Board toggles a grey overlay to the entire page 
- various text view alignments

![image](https://github.com/ngjstn/plot-pals/assets/89366060/4d054608-e432-47f5-a341-667fd20c5980)

![image](https://github.com/ngjstn/plot-pals/assets/89366060/06420d79-cac0-4e74-9dd1-a2977d0ee908)

![image](https://github.com/ngjstn/plot-pals/assets/89366060/c54d19bd-b4f0-45c4-bed1-2e2947f32c69)

![image](https://github.com/ngjstn/plot-pals/assets/89366060/843833de-c811-4a2b-8d0f-f89d50715445)
