### PR TITLE
fixed feedback for owner button and new task form back routing

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/ForumBoardNewTaskActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ForumBoardNewTaskActivity.java
@@ -99,13 +99,13 @@ public class ForumBoardNewTaskActivity extends NavBarActivity {
                     Log.d(TAG, currentGardenName + currentGardenId);
 
                     sendTaskInformation();
-
-                    startActivity(intent);
+                    finish();
                 }
 
             }
             catch (DateTimeParseException e) {
                 Toast.makeText(ForumBoardNewTaskActivity.this, deadlineText.getText().toString()+"Please enter a valid deadline", Toast.LENGTH_SHORT).show();
+                finish();
             }
         });
     }

--- a/frontend/app/src/main/java/com/plotpals/client/ForumBoardViewTaskActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/ForumBoardViewTaskActivity.java
@@ -40,7 +40,7 @@ public class ForumBoardViewTaskActivity extends NavBarActivity {
         loadTask();
 
         ImageView arrow = findViewById(R.id.forum_board_task_arrow);
-        arrow.setOnClickListener(v -> finish());
+        arrow.setOnClickListener(view -> finish());
 
     }
 
@@ -110,19 +110,26 @@ public class ForumBoardViewTaskActivity extends NavBarActivity {
     private void setButton() {
         Button button = findViewById(R.id.forum_board_task_button);
         if (!task.getTask().isAssigneeIsProvidedFeedback() && task.getTask().isCompleted() && task.getAssignerId().equals(googleProfileInformation.getAccountUserId())) { // task is complete and we made it and no feedback
-            button.setText("Provide Feedback");
-            button.setOnClickListener(view -> {
-                Toast.makeText(ForumBoardViewTaskActivity.this, "Provide Feedback Button Pressed", Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(ForumBoardViewTaskActivity.this, ForumBoardFeedbackActivity.class);
-                googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
-                intent.putExtra("taskTitle", task.getTitle());
-                intent.putExtra("taskAssignee", task.getTask().getAssigneeName());
-                intent.putExtra("taskId", task.getTask().getId());
-                intent.putExtra("gardenId", task.getPostGardenId());
-                intent.putExtra("gardenName", task.getGardenName());
-                startActivity(intent);
-                finish();
-            });
+            if (task.getTask().getAssigneeId().equals(task.getAssignerId())) {
+                // owner volunteers for their own task, disable feedback button
+                button.setVisibility(View.GONE);
+            }
+            else {
+                button.setVisibility(View.VISIBLE);
+                button.setText("Provide Feedback");
+                button.setOnClickListener(view -> {
+                    Toast.makeText(ForumBoardViewTaskActivity.this, "Provide Feedback Button Pressed", Toast.LENGTH_SHORT).show();
+                    Intent intent = new Intent(ForumBoardViewTaskActivity.this, ForumBoardFeedbackActivity.class);
+                    googleProfileInformation.loadGoogleProfileInformationToIntent(intent);
+                    intent.putExtra("taskTitle", task.getTitle());
+                    intent.putExtra("taskAssignee", task.getTask().getAssigneeName());
+                    intent.putExtra("taskId", task.getTask().getId());
+                    intent.putExtra("gardenId", task.getPostGardenId());
+                    intent.putExtra("gardenName", task.getGardenName());
+                    startActivity(intent);
+                    finish();
+                });
+            }
         } else if (task.getTask().isCompleted() ){  // || task.getAssignerId().equals(googleProfileInformation.getAccountUserId())
             button.setVisibility(View.GONE);
         } else if (task.getTask().getAssigneeName().equals("null")) { // nobody is assigned


### PR DESCRIPTION
Changes: 
- feedback button now doesn't display if the owner is the one assigned to the task 
- fixed a bug where submitting a new task form and clicking the back button caused it to route back to the form submission page 

Test procedure: 
1. Create a test in a Garden that you own 
2. Select the task and volunteer for it 
3. When you click the button to complete the task, the button should disappear entirely 
4. No feedback button should be present in the task page 