### PR TITLE
Join garden button routes page to member view 

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoMemberActivity.java
@@ -72,6 +72,7 @@ public class GardenInfoMemberActivity extends NavBarActivity {
                 forumBoard.putExtra("gardenId", gardenId);
                 forumBoard.putExtra("gardenName", gardenName);
                 startActivity(forumBoard);
+                finish();
             }
         });
 

--- a/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenInfoNonMemberActivity.java
@@ -2,6 +2,7 @@ package com.plotpals.client;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -47,6 +48,17 @@ public class GardenInfoNonMemberActivity extends AppCompatActivity {
                 Toast.makeText(GardenInfoNonMemberActivity.this, "Join pressed", Toast.LENGTH_SHORT).show();
                 try {
                     joinGardenRole(RoleEnum.CARETAKER);
+                    Intent memberPage = new Intent(GardenInfoNonMemberActivity.this, GardenInfoMemberActivity.class);
+                    googleProfileInformation.loadGoogleProfileInformationToIntent(memberPage);
+                    memberPage.putExtra("gardenId", gardenId);
+                    memberPage.putExtra("gardenName", currentGarden.getGardenName());
+
+                    // used for mapActivity callback to update the garden overlay
+                    Intent resultIntent = new Intent(GardenInfoNonMemberActivity.this, MapsActivity.class);
+                    setResult(RESULT_OK, resultIntent);
+
+                    startActivity(memberPage);
+                    finish();
                 } catch (JSONException e) {
                     Log.d(TAG, "Error joining garden");
                 }

--- a/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/MapsActivity.java
@@ -1,11 +1,16 @@
 package com.plotpals.client;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -126,7 +131,7 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                     Intent gardenInfoNonMem = new Intent(MapsActivity.this, GardenInfoNonMemberActivity.class);
                     googleProfileInformation.loadGoogleProfileInformationToIntent(gardenInfoNonMem);
                     gardenInfoNonMem.putExtra("gardenId", currentGardenSelected.getId());
-                    startActivity(gardenInfoNonMem);
+                    nonMemberActivityResultLauncher.launch(gardenInfoNonMem);
                 }
                 else {
                     Intent gardenInfo = new Intent(MapsActivity.this, GardenInfoMemberActivity.class);
@@ -137,8 +142,20 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                 }
             }
         });
-
     }
+
+    ActivityResultLauncher<Intent> nonMemberActivityResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (result.getResultCode() == Activity.RESULT_OK) {
+                        updateGardenOverlayContent(currentGardenSelected);
+                        requestMembersAndShowOverlay(currentGardenSelected.getId());
+                    }
+                }
+            }
+    );
 
     /**
      * Manipulates the map once available.
@@ -190,7 +207,6 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
             // do nothing
             return;
         }
-
         locationLat = location.getLatitude();
         locationLong = location.getLongitude();
 

--- a/frontend/app/src/main/java/com/plotpals/client/utils/GardenBaseAdapter.java
+++ b/frontend/app/src/main/java/com/plotpals/client/utils/GardenBaseAdapter.java
@@ -72,6 +72,7 @@ public class GardenBaseAdapter extends BaseAdapter {
                 mapsIntent.putExtra("moveToSelectedLat", listGarden.get(i).getLocation().latitude);
                 mapsIntent.putExtra("moveToSelectedLong", listGarden.get(i).getLocation().longitude);
                 searchActivity.startActivity(mapsIntent);
+                searchActivity.finish();
             }
         });
 

--- a/frontend/app/src/main/res/layout/activity_homepage.xml
+++ b/frontend/app/src/main/res/layout/activity_homepage.xml
@@ -42,6 +42,7 @@
         android:id="@+id/username"
         android:layout_width="300dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
         android:layout_marginTop="116dp"
         android:fontFamily="@font/inter_bold"
         android:text="{Name}"


### PR DESCRIPTION
When accessing the non-member garden info page (Garden Discovery -> More Info/Join button), clicking the join button now immediately redirects to the member view info page. 

Test steps: 
1. Open the garden discovery map and click on a garden marker that you haven't joined 
2. The garden overlay should appear and the only button on it should be "More Info/Join". Click this. 
3. Non-member view should appear with a Join button on the bottom right. Click it and it should redirect to the member view page
4. Now click the back arrow to return to the maps activity. The map focus should still have the garden overlay open on the selected garden, and it should be updated with the forum board button now that you've joined the Garden as a caretaker. 