### PR TITLE
garden application form UI and routing fix

### DIFF
--- a/frontend/app/src/main/java/com/plotpals/client/GardenApplicationActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenApplicationActivity.java
@@ -1,5 +1,6 @@
 package com.plotpals.client;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -7,6 +8,11 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 
 import com.plotpals.client.utils.GoogleProfileInformation;
 
@@ -32,8 +38,7 @@ public class GardenApplicationActivity extends NavBarActivity {
         activateNavBar();
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
 
-        TextView contactName = findViewById(R.id.garden_contact_name_loaded);
-        contactName.setText(googleProfileInformation.getAccountGoogleName());
+        findViewById(R.id.close_icon).setOnClickListener(view -> finish());
 
         gardenName = findViewById(R.id.garden_name_input);
         gardenAddress = findViewById(R.id.garden_address_input);
@@ -61,12 +66,23 @@ public class GardenApplicationActivity extends NavBarActivity {
                     gardenAppConfIntent.putExtra("gardenPhone", gardenPhone.getText().toString());
                     gardenAppConfIntent.putExtra("gardenEmail", gardenEmail.getText().toString());
                     googleProfileInformation.loadGoogleProfileInformationToIntent(gardenAppConfIntent);
-                    startActivity(gardenAppConfIntent);
-                    finish();
+                    confirmAppResultLauncher.launch(gardenAppConfIntent);
                 }
             }
         });
     }
+
+    ActivityResultLauncher<Intent> confirmAppResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (result.getResultCode() == Activity.RESULT_OK) {
+                        finish();
+                    }
+                }
+            }
+    );
 
     private boolean parseGardenInformation() {
         boolean checkStatus = true;

--- a/frontend/app/src/main/java/com/plotpals/client/GardenApplicationConfirmActivity.java
+++ b/frontend/app/src/main/java/com/plotpals/client/GardenApplicationConfirmActivity.java
@@ -1,7 +1,6 @@
 package com.plotpals.client;
 
-import androidx.appcompat.app.AppCompatActivity;
-
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -22,7 +21,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GardenApplicationConfirmActivity extends AppCompatActivity {
+public class GardenApplicationConfirmActivity extends NavBarActivity {
     final static String TAG = "GardenApplicationConfActivity";
     GoogleProfileInformation googleProfileInformation;
     private String gardenName;
@@ -35,6 +34,7 @@ public class GardenApplicationConfirmActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         loadExtras();
+        activateNavBar();
         setContentView(R.layout.activity_garden_application_confirm);
 
         Bundle applicationExtras = getIntent().getExtras();
@@ -57,6 +57,8 @@ public class GardenApplicationConfirmActivity extends AppCompatActivity {
         gardenPhoneDisplay.setText(gardenPhone);
         gardenEmailDisplay.setText(gardenEmail);
         gardenContactNameDisplay.setText(googleProfileInformation.getAccountGoogleName());
+
+        findViewById(R.id.arrow_back_).setOnClickListener(view -> finish());
 
         Button confirmButton = findViewById(R.id.confirm_application_button);
         confirmButton.setOnClickListener(new View.OnClickListener() {
@@ -88,12 +90,16 @@ public class GardenApplicationConfirmActivity extends AppCompatActivity {
                     try {
                         Log.d(TAG, "Response for submitting form: \n" + response.getString("success"));
                         Toast.makeText(this, "Form has been submitted for approval", Toast.LENGTH_LONG).show();
+                        Intent resultIntent = new Intent(GardenApplicationConfirmActivity.this, GardenApplicationActivity.class);
+                        setResult(RESULT_OK, resultIntent);
                         finish();
                     } catch (JSONException e) {
+                        Toast.makeText(this, e.toString(), Toast.LENGTH_LONG).show();
                         Log.d(TAG, e.toString());
                     }
                 },
                 (VolleyError e) -> {
+                    Toast.makeText(this, "Failed to submit form; address is likely invalid. Do not use abbreviations, eg. use Street instead of St", Toast.LENGTH_LONG).show();
                     Log.d(TAG, e.toString());
                 }
         ) {

--- a/frontend/app/src/main/res/drawable/arrow_forward_ios.xml
+++ b/frontend/app/src/main/res/drawable/arrow_forward_ios.xml
@@ -3,11 +3,21 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
+  <path
+      android:pathData="M0,0h24v24h-24z"
+      android:fillColor="#1E1E1E"/>
   <group>
     <clip-path
-        android:pathData="M0,0h24v24h-24z"/>
+        android:pathData="M-309,-79h360v800h-360z"/>
     <path
-        android:pathData="M8.025,22L6.25,20.225L14.475,12L6.25,3.775L8.025,2L18.025,12L8.025,22Z"
-        android:fillColor="#ABABAB"/>
+        android:pathData="M-309,-79h360v800h-360z"
+        android:fillColor="#ffffff"/>
+    <group>
+      <clip-path
+          android:pathData="M0,0h24v24h-24z"/>
+      <path
+          android:pathData="M8.025,22.8L5.45,20.225L13.675,12L5.45,3.775L8.025,1.2L18.825,12L8.025,22.8Z"
+          android:fillColor="#1C1B1F"/>
+    </group>
   </group>
 </vector>

--- a/frontend/app/src/main/res/layout/activity_garden_application.xml
+++ b/frontend/app/src/main/res/layout/activity_garden_application.xml
@@ -6,7 +6,9 @@
     android:layout_height="match_parent"
     tools:context=".GardenApplicationActivity">
 
-    <include layout="@layout/activity_nav_bar"/>
+    <include
+        android:id="@+id/include7"
+        layout="@layout/activity_nav_bar" />
 
     <TextView
         android:id="@+id/garden_application_header"
@@ -14,8 +16,9 @@
         android:layout_height="80dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="64dp"
+        android:layout_marginStart="76dp"
         android:layout_marginTop="56dp"
+        android:fontFamily="@font/inter_bold"
         android:gravity="top"
         android:text="@string/garden_application_header"
         android:textAppearance="@style/page_header"
@@ -24,15 +27,34 @@
 
     <Button
         android:id="@+id/next_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="276dp"
-        android:layout_marginTop="68dp"
-        android:text="Submit"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:background="@drawable/arrow_forward_ios"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.906"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="@+id/include7"
+        app:layout_constraintVertical_bias="0.096" />
+
+    <View
+        android:id="@+id/close_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:background="@drawable/close_icon"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.085"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.096" />
 
     <ScrollView
+        android:id="@+id/scrollView2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
@@ -42,27 +64,31 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
+            android:orientation="vertical"
             android:paddingLeft="36dp"
-            android:paddingRight="36dp"
             android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:orientation="vertical">
+            android:paddingRight="36dp"
+            android:paddingBottom="16dp">
 
             <TextView
                 android:id="@+id/garden_name_label"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:fontFamily="@font/inter_semibold"
                 android:paddingBottom="4dp"
                 android:text="@string/garden_application_input_name"
-                android:textAppearance="@style/label_text" />
+                android:textColor="#000000"
+                android:textSize="16sp" />
 
             <EditText
                 android:id="@+id/garden_name_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
+                android:fontFamily="@font/inter"
                 android:hint="New garden name"
-                android:inputType="text" />
+                android:inputType="text"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/garden_name_error"
@@ -70,7 +96,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/garden_application_placeholder"
                 android:textAppearance="@style/label_text"
-                android:visibility="gone"/>
+                android:visibility="gone" />
 
             <TextView
                 android:id="@+id/garden_address_label"
@@ -78,19 +104,24 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
                 android:layout_alignParentTop="true"
+                android:fontFamily="@font/inter_semibold"
+                android:gravity="top"
                 android:paddingTop="24dp"
                 android:paddingBottom="4dp"
-                android:gravity="top"
                 android:text="@string/garden_application_input_address"
-                android:textAppearance="@style/label_text" />
+                android:textAppearance="@style/label_text"
+                android:textColor="#000000"
+                android:textSize="16sp" />
 
             <EditText
                 android:id="@+id/garden_address_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
+                android:fontFamily="@font/inter"
                 android:hint="New garden address"
-                android:inputType="text" />
+                android:inputType="text"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/garden_address_error"
@@ -109,20 +140,25 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
                 android:layout_alignParentTop="true"
+                android:fontFamily="@font/inter_semibold"
+                android:gravity="top"
                 android:paddingTop="24dp"
                 android:paddingBottom="4dp"
-                android:gravity="top"
                 android:text="@string/garden_application_input_plots"
-                android:textAppearance="@style/label_text" />
+                android:textAppearance="@style/label_text"
+                android:textColor="#000000"
+                android:textSize="16sp" />
 
             <EditText
                 android:id="@+id/garden_num_plots_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="16dp"
                 android:ems="10"
+                android:fontFamily="@font/inter"
                 android:hint="New garden individual plots"
-                android:inputType="text" />
+                android:inputType="number"
+                android:paddingBottom="16dp"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/garden_num_plots_error"
@@ -139,33 +175,26 @@
                 android:id="@+id/garden_contact_info"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentTop="true"
+                android:fontFamily="@font/inter_semibold"
+                android:gravity="top"
                 android:paddingTop="24dp"
                 android:paddingBottom="4dp"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentTop="true"
-                android:gravity="top"
                 android:text="@string/garden_application_input_contact"
-                android:textAppearance="@style/label_text" />
-
-            <TextView
-                android:id="@+id/garden_contact_name_loaded"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="4dp"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentTop="true"
-                android:gravity="top"
-                android:text="@string/garden_application_placeholder"
-                android:textAppearance="@style/label_text" />
+                android:textAppearance="@style/label_text"
+                android:textColor="#000000"
+                android:textSize="16sp" />
 
             <EditText
                 android:id="@+id/garden_phone_number_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
+                android:fontFamily="@font/inter"
                 android:hint="Phone number"
-                android:inputType="text" />
+                android:inputType="phone"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/garden_phone_error"
@@ -183,8 +212,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ems="10"
+                android:fontFamily="@font/inter"
                 android:hint="Email address"
-                android:inputType="text" />
+                android:inputType="text"
+                android:textColor="#000000"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/garden_email_error"

--- a/frontend/app/src/main/res/layout/activity_garden_application_confirm.xml
+++ b/frontend/app/src/main/res/layout/activity_garden_application_confirm.xml
@@ -6,85 +6,123 @@
     android:layout_height="match_parent"
     tools:context=".GardenApplicationConfirmActivity">
 
+    <include
+        android:id="@+id/include8"
+        layout="@layout/activity_nav_bar"
+        tools:layout_editor_absoluteX="0dp"
+        tools:layout_editor_absoluteY="0dp" />
+
     <Button
         android:id="@+id/confirm_application_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="284dp"
-        android:layout_marginTop="36dp"
-        android:text="Confirm"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/check_icon"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.888"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.079" />
+
+    <View
+        android:id="@+id/arrow_back_"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/arrow_back_ios_new"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.098"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.1" />
 
     <TextView
         android:id="@+id/confirm_application_header"
-        android:layout_width="169dp"
-        android:layout_height="72dp"
+        android:layout_width="175dp"
+        android:layout_height="80dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="60dp"
+        android:fontFamily="@font/inter_bold"
         android:gravity="top"
         android:text="@string/garden_application_confirm_header"
         android:textAppearance="@style/page_header"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.38"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.09" />
 
     <TextView
-        android:id="@+id/garden_name_label"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+        android:id="@+id/description"
+        android:layout_width="320dp"
+        android:layout_height="60dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="168dp"
+        android:layout_marginBottom="508dp"
+        android:fontFamily="@font/inter"
         android:gravity="top"
-        android:text="@string/garden_application_input_name"
-        android:textAppearance="@style/label_text"
+        android:text="Please review the following before submitting. Your garden will be active after admin approval."
+        android:textAppearance="@style/existing_ga"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.555"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="@+id/include8"
+        app:layout_constraintVertical_bias="0.938" />
 
-    <TextView
-        android:id="@+id/garden_name_placeholder"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+    <View
+        android:id="@+id/person"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="208dp"
-        android:gravity="top"
-        android:text="@string/garden_application_placeholder"
-        android:textAppearance="@style/label_text"
+        android:background="@drawable/person"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.107"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.7" />
 
-    <TextView
-        android:id="@+id/garden_address_label"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+    <View
+        android:id="@+id/mail"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="248dp"
-        android:gravity="top"
-        android:text="@string/garden_application_input_address"
-        android:textAppearance="@style/label_text"
+        android:background="@drawable/mail"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.107"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.8" />
 
-    <TextView
-        android:id="@+id/garden_address_placeholder"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+    <View
+        android:id="@+id/call"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="288dp"
-        android:gravity="top"
-        android:text="@string/garden_application_placeholder"
-        android:textAppearance="@style/label_text"
+        android:background="@drawable/call"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.107"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.751" />
 
     <TextView
         android:id="@+id/garden_plot_label"
@@ -92,27 +130,104 @@
         android:layout_height="19dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="340dp"
         android:gravity="top"
         android:text="@string/garden_application_input_plots"
         android:textAppearance="@style/label_text"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.173"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.547" />
 
     <TextView
-        android:id="@+id/garden_plot_placeholder"
+        android:id="@+id/garden_name_label"
         android:layout_width="wrap_content"
         android:layout_height="19dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="372dp"
+        android:gravity="top"
+        android:text="@string/garden_application_input_name"
+        android:textAppearance="@style/label_text"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.127"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.356" />
+
+    <TextView
+        android:id="@+id/garden_name_placeholder"
+        android:layout_width="300dp"
+        android:layout_height="25dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="10dp"
+        android:fontFamily="@font/inter"
         android:gravity="top"
         android:text="@string/garden_application_placeholder"
         android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.378"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.393" />
+
+    <TextView
+        android:id="@+id/garden_address_label"
+        android:layout_width="wrap_content"
+        android:layout_height="19dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:gravity="top"
+        android:text="@string/garden_application_input_address"
+        android:textAppearance="@style/label_text"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.136"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.452" />
+
+    <TextView
+        android:id="@+id/garden_address_placeholder"
+        android:layout_width="300dp"
+        android:layout_height="25dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="13dp"
+        android:fontFamily="@font/inter"
+        android:gravity="top"
+        android:text="@string/garden_application_placeholder"
+        android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.378"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.478" />
+
+    <TextView
+        android:id="@+id/garden_plot_placeholder"
+        android:layout_width="wrap_content"
+        android:layout_height="25dp"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentTop="true"
+        android:fontFamily="@font/inter"
+        android:gravity="top"
+        android:text="@string/garden_application_placeholder"
+        android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.126"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.584" />
 
     <TextView
         android:id="@+id/garden_contact_label"
@@ -120,54 +235,69 @@
         android:layout_height="19dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="420dp"
         android:gravity="top"
         android:text="@string/garden_application_input_contact"
         android:textAppearance="@style/label_text"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.153"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.66" />
 
     <TextView
         android:id="@+id/garden_contact_name_placeholder"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+        android:layout_width="300dp"
+        android:layout_height="25dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="456dp"
+        android:layout_marginStart="20dp"
+        android:fontFamily="@font/inter"
         android:gravity="top"
         android:text="@string/garden_application_placeholder"
         android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.684"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.705" />
 
     <TextView
         android:id="@+id/garden_contact_phone_placeholder"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+        android:layout_width="300dp"
+        android:layout_height="25dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="492dp"
+        android:layout_marginStart="20dp"
+        android:fontFamily="@font/inter"
         android:gravity="top"
         android:text="@string/garden_application_placeholder"
         android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.684"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.756" />
 
     <TextView
         android:id="@+id/garden_contact_email_placeholder"
-        android:layout_width="wrap_content"
-        android:layout_height="19dp"
+        android:layout_width="300dp"
+        android:layout_height="25dp"
         android:layout_alignParentLeft="true"
         android:layout_alignParentTop="true"
-        android:layout_marginStart="60dp"
-        android:layout_marginTop="536dp"
+        android:layout_marginStart="20dp"
+        android:fontFamily="@font/inter"
         android:gravity="top"
         android:text="@string/garden_application_placeholder"
         android:textAppearance="@style/label_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.684"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.805" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Changes: 
- updated UI for new garden application and application confirmation pages 
- fixed routing bug where clicking the back arrow on the app confirmation page would also kill the form entries from the application page 
- added logging/toast when submitting an invalid form (eg. bad address) 

Please verify that the gardens application process still works. 

![image](https://github.com/ngjstn/plot-pals/assets/89366060/ed9cf7b3-c55b-44a3-aadb-bfb3539580d8)

![image](https://github.com/ngjstn/plot-pals/assets/89366060/47c5c4d2-7c2d-4308-ab24-9a2c4801201f)
